### PR TITLE
Fix WAV format, when 'fmt' tag is longer than 16 bytes

### DIFF
--- a/format/wav/Reader.hx
+++ b/format/wav/Reader.hx
@@ -76,6 +76,12 @@ class Reader {
 		var blockAlign = i.readUInt16();
 		var bitsPerSample = i.readUInt16();
 		
+		if (fmtlen > 16) {
+			
+			i.read(fmtlen - 16);
+			
+		}
+		
 		var nextChunk = i.readString (4);
 		
 		while (nextChunk != "data") {


### PR DESCRIPTION
Some WAV files may have a longer "fmt" tag, such as 18 bytes instead of 16. Under the current logic, the reader will attempt to read four bytes to get the name of the next tag. In this case (2 extra bytes) it will read only half of the next tag name, and quite probably fail to read additional tags until it reaches the end of the file.

WAV embedding is working here, again :)
