### PR TITLE
Fixing a typo in documentation

### DIFF
--- a/format/png/Tools.hx
+++ b/format/png/Tools.hx
@@ -100,7 +100,7 @@ class Tools {
 	}
 
 	/**
-		Decode the greyscale PNG data and apply nilters, extracting only the grey channel if alpha is present.
+		Decode the greyscale PNG data and apply filters, extracting only the grey channel if alpha is present.
 	**/
 	@:noDebug
 	public static function extractGrey( d : Data ) : haxe.io.Bytes {


### PR DESCRIPTION
Small typo in doc: "filters". :)
