### PR TITLE
Gif file format support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+2014-11-12: 3.1.2
+	fix for png
+	added format.amf3 support
+
 2014-09-06: 3.1.1
 	added indexed png with <8 bits palette indexes support
 	completed AGAL2 support

--- a/format/gif/Data.hx
+++ b/format/gif/Data.hx
@@ -3,34 +3,54 @@ package format.gif;
 import haxe.io.Bytes;
 
 /**
- * ...
- * @author Yanrishatum
+ * Gif data.
  */
-
 typedef Data =
 {
+  /**
+   * Gif version. There is only 2 Gif version exists. 87a and 89a.
+   * 87a have less features and does not support any extensions.
+   * Unknown version is adviced to be interpreted as newest (89a) official version.
+   */
   var version:Version;
+  /**
+   * Information about logical screen of Gif that provides basic information about Gif.
+   */
   var logicalScreenDescriptor:LogicalScreenDescriptor;
+  /**
+   * Global color table used for Gif. Present only if Logical Screen Descriptor contained global color table flag.
+   * Note that this color table not always present since frames can contain local color tables that overrides global color table.
+   */
   @:optional var globalColorTable:Null<ColorTable>;
+  /**
+   * List of Gif data blocks.
+   */
   var blocks:List<Block>;
 }
 
+/**
+ * Gif data block. Custom blocks are not supported.
+ */
 enum Block
 {
   /**
    * Gif frame block.
+   * Note that this block does not contain link to graphic control extension of Frame even if it is present. GraphicControl extension Block commonly present right before frame Block.
    */
   BFrame(frame:Frame);
   /**
-   * Additional extension block.
+   * Additional extension block. This Block does not supported in 87a Gif specification version.
    */
   BExtension(extension:Extension);
   /**
-   * End of File block.
+   * End of File block. Represents end of Gif data.
    */
   BEOF;
 }
 
+/**
+ * Extension block contains additional data about Gif image. This block does not supported by 87a version.
+ */
 enum Extension
 {
   /**
@@ -46,7 +66,7 @@ enum Extension
    */
   EText(pte:PlainTextExtension);
   /**
-   * Application extension allow to insert additional application data into Gif. Most used app extension is NETSCAPE2.0 looping extension, used to set up amount of loops in frame.
+   * Application extension allow to insert additional application data into Gif. Mostly used app extension is NETSCAPE2.0 looping extension, used to set up amount of loops in frame.
    */
   EApplicationExtension(ext:ApplicationExtension);
   
@@ -56,9 +76,19 @@ enum Extension
   EUnknown(id:Int, data:Bytes);
 }
 
+/**
+ * Application extension. Mostly used only for one reason - setting up loops count. There is exist other app extensions but they are really rare.
+ */
 enum ApplicationExtension
 {
+  /**
+   * NETSCAPE2.0 looping extension. Contains only amount of animation repeats.
+   * Note that there is two NETSCAPE2.0 app extensions for Gif format and the type of extension is stored in first byte of data. Looping extension have ID 1.
+   */
   AENetscapeLooping(loops:Int);
+  /**
+   * Unknown or unsupported app extension.
+   */
   AEUnknown(name:String, version:String, data:Bytes);
 }
 
@@ -69,6 +99,16 @@ enum ApplicationExtension
  */
 typedef ColorTable = Bytes;
 
+/**
+ * Single frame of the image.
+ * Actually it's a merge of 3 consequent blocks:
+ * 1. Image Descriptor.
+ * Contains frame informations like position, size, existing of local color table and interlaced flag.
+ * 2. [Local color table].
+ * Only present if Image Descriptor contains local color table flag. Overrides global color table.
+ * 3. Pixel data blocks.
+ * LZW compressed pixel data.
+ */
 typedef Frame =
 {
   /**
@@ -98,6 +138,7 @@ typedef Frame =
   
   /**
    * Is this image written in interlace mode?
+   * Note: The pixel data already deinterlaced and this flag presented only for information purpose (and for Writer when there is one).
    */
   var interlaced:Bool;
   
@@ -133,7 +174,7 @@ typedef GraphicControlExtension =
   var disposalMethod:DisposalMethod;
   /**
    * Is image must wait for user input, before dispose?
-   * This flag may be used by user-defined program.
+   * This flag may be used by user-defined program but absolutely ignored by any Gif players.
    */
   var userInput:Bool;
   /**
@@ -142,6 +183,8 @@ typedef GraphicControlExtension =
   var hasTransparentColor:Bool;
   /**
    * Delay, before next image appears. Delay is in centiseconds (1 centisecond = 1/100 seconds).
+   * Note: Some players (like FastStone) cut fraction of elapsed time when progressing to next frame which results in small timing error.
+   * Recommended to use `time -= delay` instead of `time = 0`.
    */
   var delay:Int;
   /**
@@ -150,21 +193,55 @@ typedef GraphicControlExtension =
   var transparentIndex:Int;
 }
 
+/**
+ * Extension for rendering text on Gif logical screen. It does not supported by major Gif decoders.
+ * Font and text size decision is left to decoder. (recommended to decide based on grid/cell size)
+ * Text must be rendered with one character at cell.
+ * It's recommended to replace any characters less than 0x20 and greater than 0xf7 to be rendered as Space (0x20)
+ */
 typedef PlainTextExtension =
 {
+  /**
+   * X position of text grid on Logical Screen.
+   */
   var textGridX:Int;
+  /**
+   * Y position of text grid on Logical Screen.
+   */
   var textGridY:Int;
+  /**
+   * Width of text grid in pixels.
+   */
   var textGridWidth:Int;
+  /**
+   * Height of text grid in pixels.
+   */
   var textGridHeight:Int;
+  /**
+   * Width of character cell in text grid.
+   */
   var charCellWidth:Int;
+  /**
+   * Height of character cell in text grid.
+   */
   var charCellHeight:Int;
+  /**
+   * Foreground/character color index.
+   */
   var textForegroundColorIndex:Int;
+  /**
+   * Background color index.
+   */
   var textBackgroundColorIndex:Int;
+  /**
+   * Text to render.
+   */
   var text:String;
 }
 
 /**
  * Logical screen descriptor of GIF file.
+ * Contains very basic information about Gif.
  */
 typedef LogicalScreenDescriptor =
 {
@@ -232,13 +309,13 @@ typedef LogicalScreenDescriptor =
 enum Version
 {
   /**
-   * First version of Gif file format from year 1987.
+   * First version of Gif file format from May 1987.
    * 
    * Note: The checking of unsupported blocks disabled by default to save some time. To enable supported blocks check set `yagp_strict_version_check` debug variable.
    */
   GIF87a;
   /**
-   * Second and actual version of Gif file format from year 1989.
+   * Second and actual version of Gif file format from July 1989.
    */
   GIF89a;
   /**

--- a/format/gif/Data.hx
+++ b/format/gif/Data.hx
@@ -1,0 +1,280 @@
+package format.gif;
+
+import haxe.io.Bytes;
+
+/**
+ * ...
+ * @author Yanrishatum
+ */
+
+typedef Data =
+{
+  var version:Version;
+  var logicalScreenDescriptor:LogicalScreenDescriptor;
+  @:optional var globalColorTable:Null<ColorTable>;
+  var blocks:List<Block>;
+}
+
+enum Block
+{
+  /**
+   * Gif frame block.
+   */
+  BFrame(frame:Frame);
+  /**
+   * Additional extension block.
+   */
+  BExtension(extension:Extension);
+  /**
+   * End of File block.
+   */
+  BEOF;
+}
+
+enum Extension
+{
+  /**
+   * Graphic Control extension gives additional control over next frame, like frame delay, disposal method, alpha channel and other information.
+   */
+  EGraphicControl(gce:GraphicControlExtension);
+  /**
+   * Commentary extension. Not show up as any visual, just a text in file.
+   */
+  EComment(text:String);
+  /**
+   * Text extension. Must work as text rendering on the image, but ignored by all major Gif decoders.
+   */
+  EText(pte:PlainTextExtension);
+  /**
+   * Application extension allow to insert additional application data into Gif. Most used app extension is NETSCAPE2.0 looping extension, used to set up amount of loops in frame.
+   */
+  EApplicationExtension(ext:ApplicationExtension);
+  
+  /**
+   * Unknown extension. 
+   */
+  EUnknown(id:Int, data:Bytes);
+}
+
+enum ApplicationExtension
+{
+  AENetscapeLooping(loops:Int);
+  AEUnknown(name:String, version:String, data:Bytes);
+}
+
+/**
+ * Typical color table for Gif image.
+ * Can contain 2, 4, 8, 16, 32, 64, 128 or 256 colors.
+ * Data stored in RGB format. Information about alpha channel provided by Graohic Control Extension.
+ */
+typedef ColorTable = Bytes;
+
+typedef Frame =
+{
+  /**
+   * X position of image on the Logical Screen
+   */
+  var x:Int;
+  
+  /**
+   * Y position of image on the Logical Screen
+   */
+  var y:Int;
+  
+  /**
+   * Width of image in pixels
+   */
+  var width:Int;
+  
+  /**
+   * Height of image in pixels
+   */
+  var height:Int;
+  
+  /**
+   * Is this image uses local color table?
+   */
+  var localColorTable:Bool;
+  
+  /**
+   * Is this image written in interlace mode?
+   */
+  var interlaced:Bool;
+  
+  /**
+   * Is local color table sorted in order of decreasing priority?
+   */
+  var sorted:Bool;
+  
+  /**
+   * Size of local color table
+   */
+  var localColorTableSize:Int;
+  
+  /**
+   * Pixel data of frame. Stored as Indexed colors, 1 byte per pixel.
+   */
+  var pixels:Bytes;
+  
+  /**
+   * Local color table used by frame. Stored as 3-byte RGB colors. If value is null, must be used global color table.
+   */
+  var colorTable:ColorTable;
+}
+
+/**
+ * Graphic Control Extension block, used for setting up disposal method, transparency, delay and user input.
+ */
+typedef GraphicControlExtension =
+{
+  /**
+   * Disposal method of frame.
+   */
+  var disposalMethod:DisposalMethod;
+  /**
+   * Is image must wait for user input, before dispose?
+   * This flag may be used by user-defined program.
+   */
+  var userInput:Bool;
+  /**
+   * Is image have transparency?
+   */
+  var hasTransparentColor:Bool;
+  /**
+   * Delay, before next image appears. Delay is in centiseconds (1 centisecond = 1/100 seconds).
+   */
+  var delay:Int;
+  /**
+   * Index in color table that used as transparent.
+   */
+  var transparentIndex:Int;
+}
+
+typedef PlainTextExtension =
+{
+  var textGridX:Int;
+  var textGridY:Int;
+  var textGridWidth:Int;
+  var textGridHeight:Int;
+  var charCellWidth:Int;
+  var charCellHeight:Int;
+  var textForegroundColorIndex:Int;
+  var textBackgroundColorIndex:Int;
+  var text:String;
+}
+
+/**
+ * Logical screen descriptor of GIF file.
+ */
+typedef LogicalScreenDescriptor =
+{
+  /**
+   * Width of GIF image in pixels
+   */
+  var width:Int;
+  
+  /**
+   * Height of GIF image in pixels
+   */
+  var height:Int;
+  
+  /**
+   * Is this file uses global color table?
+   */
+  var hasGlobalColorTable:Bool;
+  
+  /**
+   * Specification:
+   * Number of bits per primary color available
+     to the original image, minus 1. This value represents the size of
+     the entire palette from which the colors in the graphic were
+     selected, not the number of colors actually used in the graphic.
+     For example, if the value in this field is 3, then the palette of
+     the original image had 4 bits per primary color available to create
+     the image.  This value should be set to indicate the richness of
+     the original palette, even if not every color from the whole
+     palette is available on the source machine.
+   */
+  var colorResolution:Int;
+  
+  /**
+   * Specification:
+   * Indicates whether the Global Color Table is sorted.
+     If the flag is set, the Global Color Table is sorted, in order of
+     decreasing importance. Typically, the order would be decreasing
+     frequency, with most frequent color first. This assists a decoder,
+     with fewer available colors, in choosing the best subset of colors;
+     the decoder may use an initial segment of the table to render the
+     graphic.
+   */
+  var sorted:Bool;
+  
+  /**
+   * Size of global color table.
+   */
+  var globalColorTableSize:Int;
+  
+  /**
+   * Background color index in global color table
+   */
+  var backgroundColorIndex:Int;
+  
+  /**
+   * Factor used to compute an approximation of the aspect ratio of the pixel in the original image.
+   */
+  var pixelAspectRatio:Float;
+}
+
+/**
+ * Version of Gif file.  
+ * The only 2 official versions is GIF87a and GIF89a.
+ */
+enum Version
+{
+  /**
+   * First version of Gif file format from year 1987.
+   * 
+   * Note: The checking of unsupported blocks disabled by default to save some time. To enable supported blocks check set `yagp_strict_version_check` debug variable.
+   */
+  GIF87a;
+  /**
+   * Second and actual version of Gif file format from year 1989.
+   */
+  GIF89a;
+  /**
+   * Unknown version of Gif file.
+   */
+  Unknown(version:String);
+}
+
+/**
+ * Disposal method of GIF frame.
+ */
+enum DisposalMethod
+{
+  /**
+   * The disposal method is unspecified. Action on demand of viewer.
+   * 
+   * Mostly interpreted as NO_ACTION.
+   */
+  UNSPECIFIED;
+  /**
+   * No action required. 
+   */
+  NO_ACTION;
+  /**
+   * Fill frame rectangle with background color.
+   * 
+   * Usage note: 
+   * Most renderers clears to transparency instead of filling background color, when frame's transparent color index not equals to background color index.
+   */
+  FILL_BACKGROUND;
+  /**
+   * Render previous state of gif as it before rendering disposing frame.
+   */
+  RENDER_PREVIOUS;
+  /**
+   * Reserved disposal methods.
+   */
+  UNDEFINED(index:Int);
+}

--- a/format/gif/Reader.hx
+++ b/format/gif/Reader.hx
@@ -1,0 +1,346 @@
+package format.gif;
+import format.gif.Data;
+import haxe.io.Bytes;
+import haxe.io.BytesOutput;
+import haxe.io.Input;
+
+/**
+ * ...
+ * @author Yanrishatum
+ */
+class Reader
+{
+
+  private var i:Input;
+  
+  public function new(i:Input) 
+  {
+    this.i = i;
+    i.bigEndian = false;
+  }
+  
+  public function read():Data
+  {
+    for (b in [71, 73, 70])
+    {
+      if (i.readByte() != b) throw "Invalid header";
+    }
+    
+    var gifVer:String = i.readString(3);
+    var version:Version = Version.GIF89a;
+    switch(gifVer)
+    {
+      case "87a": version = Version.GIF87a;
+      case "89a": version = Version.GIF89a;
+      default: version = Version.Unknown(gifVer);
+    }
+    
+    // Logical screen descriptor.
+    var width:Int = i.readUInt16();
+    var height:Int = i.readUInt16();
+    var packedField:Int = i.readByte();
+    var bgIndex:Int = i.readByte();
+    var pixelAspectRatio:Float = i.readByte();
+    if (pixelAspectRatio != 0) pixelAspectRatio = (pixelAspectRatio + 15) / 64;
+    else pixelAspectRatio = 1;
+    
+    var lsd:LogicalScreenDescriptor =
+    {
+      width: width,
+      height: height,
+      hasGlobalColorTable: (packedField & 128) == 128,
+      colorResolution: (packedField & 112) >>> 4,
+      sorted: (packedField & 8) == 8,
+      globalColorTableSize: 2 << (packedField & 7),
+      backgroundColorIndex: bgIndex,
+      pixelAspectRatio: pixelAspectRatio
+    }
+    
+    var gct:ColorTable = null;
+    if (lsd.hasGlobalColorTable) gct = readColorTable(lsd.globalColorTableSize);
+    
+    var blocks:List<Block> = new List();
+    
+    while (true)
+    {
+      var b:Block = readBlock();
+      blocks.add(b);
+      if (b == Block.BEOF) break;
+    }
+    
+    return
+    {
+      version: version,
+      logicalScreenDescriptor: lsd,
+      globalColorTable: gct,
+      blocks: blocks
+    }
+  }
+  
+  private function readBlock():Block
+  {
+    var blockID:Int = i.readByte();
+    switch(blockID)
+    {
+      case 0x2C:
+        // Image
+        return readImage();
+      case 0x21:
+        // Extension
+        return readExtension();
+      case 0x3B:
+        return Block.BEOF;
+    }
+    // The behaviour of taking unknown block ID is unspecified.
+    return Block.BEOF;
+  }
+  
+  private function readImage():Block
+  {
+    var x:Int = i.readUInt16();
+    var y:Int = i.readUInt16();
+    var width:Int = i.readUInt16();
+    var height:Int = i.readUInt16();
+    var packed:Int = i.readByte();
+    var localColorTable:Bool = (packed & 128) == 128;
+    var interlaced:Bool = (packed & 64) == 64;
+    var sorted:Bool = (packed & 32) == 32;
+    var localColorTableSize:Int = 2 << (packed & 7);
+    
+    var lct:ColorTable = null;
+    if (localColorTable) lct = readColorTable(localColorTableSize);
+    
+    return Block.BFrame(
+    {
+      x: x, 
+      y: y,
+      width: width,
+      height: height,
+      localColorTable: localColorTable,
+      interlaced:interlaced,
+      sorted:sorted,
+      localColorTableSize:localColorTableSize,
+      pixels:readPixels(width, height, interlaced),
+      colorTable:lct
+    });
+    
+  }
+  
+  private function readPixels(width:Int, height:Int, interlaced:Bool):Bytes
+  {
+    var input:Input = this.i;
+    
+    var pixelsCount:Int = width * height;
+    var pixels:Bytes = Bytes.alloc(pixelsCount);
+    
+    var minCodeSize:Int = input.readByte();
+    
+    var blockSize:Int = input.readByte() - 1;
+    var bits:Int = input.readByte();
+    var bitsCount:Int = 8;
+    
+    var clearCode:Int = 1 << minCodeSize;
+    var eoiCode:Int = clearCode + 1;
+    
+    var codeSize:Int = minCodeSize + 1;
+    var codeSizeLimit:Int = 1 << codeSize;
+    var codeMask = codeSizeLimit - 1;
+    
+    
+    var baseDict:Array<Array<Int>> = new Array();
+    for (i in 0...clearCode) baseDict[i] = [i];
+    
+    var dict:Array<Array<Int>> = new Array();
+    var dictLen:Int = clearCode + 2;
+    var newRecord:Array<Int>;
+    
+    var i:Int = 0;
+    var code:Int = 0;
+    var last:Int;
+    
+    while (i < pixelsCount)
+    {
+      last = code;
+      while (bitsCount < codeSize)
+      {
+        if (blockSize == 0) break;
+        bits |= input.readByte() << bitsCount;
+        bitsCount += 8;
+        blockSize--;
+        if (blockSize == 0) blockSize = input.readByte();
+      }
+      code = bits & codeMask;
+      bits >>= codeSize;
+      bitsCount -= codeSize;
+      
+      if (code == clearCode)
+      {
+        dict = baseDict.copy();
+        dictLen = clearCode + 2;
+        codeSize = minCodeSize + 1;
+        codeSizeLimit = (1 << codeSize);
+        codeMask = codeSizeLimit - 1;
+        continue;
+      }
+      if (code == eoiCode) break;
+      
+      if (code < dictLen)
+      {
+        if (last != clearCode)
+        {
+          newRecord = dict[last].copy();
+          newRecord.push(dict[code][0]);
+          dict[dictLen++] = newRecord;
+        }
+      }
+      else
+      {
+        if (code != dictLen) throw 'Invalid LZW code. Excepted: $dictLen, got: $code';
+        newRecord = dict[last].copy();
+        newRecord.push(newRecord[0]);
+        dict[dictLen++] = newRecord;
+      }
+      
+      newRecord = dict[code];
+      for (item in newRecord) pixels.set(i++, item);
+      
+      if (dictLen == codeSizeLimit && codeSize < 12)
+      {
+        codeSize++;
+        codeSizeLimit = (1 << codeSize);
+        codeMask = codeSizeLimit - 1;
+      }
+    }
+    
+    // Just in case
+    while (blockSize > 0)
+    {
+      input.readByte();
+      blockSize--;
+      if (blockSize == 0) blockSize = input.readByte();
+    }
+    
+    while (i < pixelsCount) pixels.set(i++, 0);
+    if (interlaced)
+    {
+      var buffer:Bytes = Bytes.alloc(pixelsCount);
+      var offset:Int = deinterlace(pixels, buffer, 8, 0, 0     , width, height); // Every 8 line with start at 0
+          offset     = deinterlace(pixels, buffer, 8, 4, offset, width, height); // Every 8 line with start at 4
+          offset     = deinterlace(pixels, buffer, 4, 2, offset, width, height); // Every 4 line with start at 2
+                       deinterlace(pixels, buffer, 2, 1, offset, width, height); // Every 2 line with start at 1
+      pixels = buffer;
+    }
+    return pixels;
+  }
+  
+  private function deinterlace(input:Bytes, output:Bytes, step:Int, y:Int, offset:Int, width:Int, height:Int):Int
+  {
+    while (y < height)
+    {
+      output.blit(y * width, input, offset, width);
+      offset += width;
+      y += step;
+    }
+    return offset;
+  }
+  
+  private function readExtension():Block
+  {
+    var subId:Int = i.readByte();
+    
+    switch(subId)
+    {
+      case 0xF9:
+        // Graphics Control Extension
+        if (i.readByte() != 4) throw "Incorrect Graphic Control Extension block size!";
+        var packed:Int = i.readByte();
+        var disposalMethod:DisposalMethod = switch ( (packed & 28) >> 2)
+        {
+          case 0: DisposalMethod.UNSPECIFIED;
+          case 1: DisposalMethod.NO_ACTION;
+          case 2: DisposalMethod.FILL_BACKGROUND;
+          case 3: DisposalMethod.RENDER_PREVIOUS;
+          default: DisposalMethod.UNDEFINED((packed & 28) >> 2);
+        };
+        var b:Block = Block.BExtension(Extension.EGraphicControl(
+        {
+          disposalMethod:disposalMethod,
+          userInput: (packed & 2) == 2,
+          hasTransparentColor: (packed & 1) == 1,
+          delay: i.readUInt16(),
+          transparentIndex: i.readByte()
+        }));
+        i.readByte(); // Terminator
+        return b;
+      case 0x01:
+        // Text block
+        // Exists only on paper, nobody ever used it.
+        if (i.readByte() != 12) throw "Incorrect size of Plain Text Extension introducer block.";
+        return Block.BExtension(Extension.EText(
+        {
+          textGridX: i.readUInt16(),
+          textGridY: i.readUInt16(),
+          textGridWidth: i.readUInt16(),
+          textGridHeight: i.readUInt16(),
+          charCellWidth: i.readByte(),
+          charCellHeight: i.readByte(),
+          textForegroundColorIndex: i.readByte(),
+          textBackgroundColorIndex: i.readByte(),
+          text: readBlocks().toString()
+        }));
+      case 0xFE:
+        // Commentary
+        return Block.BExtension(Extension.EComment(readBlocks().toString()));
+      case 0xFF:
+        // Application extension
+        return readApplicationExtension();
+      default:
+        return Block.BExtension(Extension.EUnknown(subId, readBlocks()));
+    }
+  }
+  
+  private function readApplicationExtension():Block
+  {
+    if (i.readByte() != 11) throw "Incorrect size of Application Extension introducer block.";
+    var name:String = i.readString(8);
+    var version:String = i.readString(3);
+    var data:Bytes = readBlocks();
+    if (name == "NETSCAPE" && version == "2.0" && data.get(0) == 1)
+    {
+      return Block.BExtension(Extension.EApplicationExtension(ApplicationExtension.AENetscapeLooping(data.get(1) | (data.get(2) << 8))));
+    }
+    return Block.BExtension(Extension.EApplicationExtension(ApplicationExtension.AEUnknown(name, version, data)));
+  }
+  
+  private inline function readBlocks():Bytes
+  {
+    var buffer:BytesOutput = new BytesOutput();
+    var bytes:Bytes = Bytes.alloc(255);
+    var len:Int = i.readByte();
+    while (len != 0)
+    {
+      i.readBytes(bytes, 0, len);
+      buffer.writeBytes(bytes, 0, len);
+      len = i.readByte();
+    }
+    buffer.flush();
+    bytes = buffer.getBytes();
+    buffer.close();
+    return bytes;
+  }
+  
+  private function readColorTable(size:Int):ColorTable
+  {
+    size *= 3;
+    var output:ColorTable = ColorTable.alloc(size);
+    var c:Int = 0;
+    while (c < size)
+    {
+      output.set(c    , i.readByte()); // R
+      output.set(c + 1, i.readByte()); // G
+      output.set(c + 2, i.readByte()); // B
+      c += 3;
+    }
+    return output;
+  }
+}

--- a/format/gif/Tools.hx
+++ b/format/gif/Tools.hx
@@ -1,0 +1,90 @@
+package format.gif;
+
+import format.gif.Data;
+import haxe.io.Bytes;
+import haxe.io.BytesData;
+
+/**
+ * ...
+ * @author Yanrishatum
+ */
+class Tools
+{
+
+  public static function framesCount(data:Data):Int
+  {
+    var frames:Int = 0;
+    for (block in data.blocks)
+    {
+      switch(block)
+      {
+        case Block.BFrame(_):
+          trace(block.getName());
+          frames++;
+        default : trace(block.getName());
+      }
+    }
+    return frames;
+  }
+  
+  public static function frameAtIndex(data:Data, frameIndex:Int):Frame
+  {
+    var frames:Int = 0;
+    for (block in data.blocks)
+    {
+      switch(block)
+      {
+        case Block.BFrame(frame):
+          if (frames == frameIndex) return frame;
+          frames++;
+        default :
+      }
+    }
+    return null;
+  }
+  
+  public static function extractBGRA(data:Data, frameIndex:Int):Bytes
+  {
+    var gce:GraphicControlExtension = null;
+    var frameCaret:Int = 0;
+    for (block in data.blocks)
+    {
+      switch (block)
+      {
+        case Block.BExtension(ext):
+          switch(ext)
+          {
+            case Extension.EGraphicControl(g):
+              gce = g;
+            default:
+          }
+        case Block.BFrame(frame):
+          if (frameCaret == frameIndex)
+          {
+            var bytes:Bytes = Bytes.alloc(frame.width * frame.height * 4);
+            var ct:Bytes = frame.localColorTable ? frame.colorTable : data.globalColorTable;
+            if (ct == null) throw "Frame does not have a color table!";
+            var transparentIndex:Int = gce != null && gce.hasTransparentColor ? gce.transparentIndex * 3 : -1;
+            var writeCaret:Int = 0;
+            for (i in 0...frame.pixels.length)
+            {
+              var index:Int = frame.pixels.get(i) * 3;
+              bytes.set(writeCaret    , ct.get(index + 2)); // B
+              bytes.set(writeCaret + 1, ct.get(index + 1)); // G
+              bytes.set(writeCaret + 2, ct.get(index    )); // R
+              if (transparentIndex == index) bytes.set(writeCaret + 3, 0); // A = 0
+              else bytes.set(writeCaret + 3, 0xFF);                        // A = FF
+              
+              writeCaret += 4;
+            }
+            return bytes;
+          }
+          frameCaret++;
+          gce = null;
+        default:
+      }
+    }
+    return null;
+  }
+  
+}

--- a/format/gif/Tools.hx
+++ b/format/gif/Tools.hx
@@ -19,9 +19,8 @@ class Tools
       switch(block)
       {
         case Block.BFrame(_):
-          trace(block.getName());
           frames++;
-        default : trace(block.getName());
+        default :
       }
     }
     return frames;
@@ -37,6 +36,26 @@ class Tools
         case Block.BFrame(frame):
           if (frames == frameIndex) return frame;
           frames++;
+        default :
+      }
+    }
+    return null;
+  }
+  
+  public static function frameGraphicControlExtension(data:Data, frameIndex:Int):GraphicControlExtension
+  {
+    var frames:Int = 0;
+    var gce:GraphicControlExtension = null;
+    for (block in data.blocks)
+    {
+      switch (block)
+      {
+        case Block.BFrame(frame):
+          if (frames == frameIndex) return gce;
+          gce = null;
+          frames++;
+        case Block.BExtension(Extension.EGraphicControl(g)):
+          gce = g;
         default :
       }
     }
@@ -87,4 +106,151 @@ class Tools
     return null;
   }
   
+  public static function extractRGBA(data:Data, frameIndex:Int):Bytes
+  {
+    var gce:GraphicControlExtension = null;
+    var frameCaret:Int = 0;
+    for (block in data.blocks)
+    {
+      switch (block)
+      {
+        case Block.BExtension(ext):
+          switch(ext)
+          {
+            case Extension.EGraphicControl(g):
+              gce = g;
+            default:
+          }
+        case Block.BFrame(frame):
+          if (frameCaret == frameIndex)
+          {
+            var bytes:Bytes = Bytes.alloc(frame.width * frame.height * 4);
+            var ct:Bytes = frame.localColorTable ? frame.colorTable : data.globalColorTable;
+            if (ct == null) throw "Frame does not have a color table!";
+            var transparentIndex:Int = gce != null && gce.hasTransparentColor ? gce.transparentIndex * 3 : -1;
+            var writeCaret:Int = 0;
+            for (i in 0...frame.pixels.length)
+            {
+              var index:Int = frame.pixels.get(i) * 3;
+              bytes.set(writeCaret    , ct.get(index    )); // R
+              bytes.set(writeCaret + 1, ct.get(index + 1)); // G
+              bytes.set(writeCaret + 2, ct.get(index + 2)); // B
+              if (transparentIndex == index) bytes.set(writeCaret + 3, 0); // A = 0
+              else bytes.set(writeCaret + 3, 0xFF);                        // A = FF
+              
+              writeCaret += 4;
+            }
+            return bytes;
+          }
+          frameCaret++;
+          gce = null;
+        default:
+      }
+    }
+    return null;
+  }
+  
+  public static function extractFullBGRA(data:Data, frameIndex:Int):Bytes
+  {
+    var gce:GraphicControlExtension = null;
+    var frameCaret:Int = 0;
+    
+    var bytes:Bytes = Bytes.alloc(data.logicalScreenDescriptor.width* data.logicalScreenDescriptor.height * 4);
+    
+    for (block in data.blocks)
+    {
+      switch (block)
+      {
+        case Block.BExtension(ext):
+          switch(ext)
+          {
+            case Extension.EGraphicControl(g):
+              gce = g;
+            default:
+          }
+        case Block.BFrame(frame):
+          var ct:Bytes = frame.localColorTable ? frame.colorTable : data.globalColorTable;
+          if (ct == null) throw "Frame does not have a color table!";
+          var transparentIndex:Int = gce != null && gce.hasTransparentColor ? gce.transparentIndex * 3 : -1;
+          var pixels:Bytes = frame.pixels;
+          var x:Int = 0;
+          var writeCaret:Int = (frame.y * data.logicalScreenDescriptor.width + frame.x) * 4;
+          var lineSkip:Int = (data.logicalScreenDescriptor.width - frame.width) * 4 + 4;
+          
+          var disposalMethod:DisposalMethod = frameCaret != frameIndex && gce != null ? gce.disposalMethod : DisposalMethod.NO_ACTION;
+          
+          switch (disposalMethod)
+          {
+            case DisposalMethod.RENDER_PREVIOUS:
+              // Do not render frame at all
+            case DisposalMethod.FILL_BACKGROUND:
+              for (i in 0...pixels.length)
+              {
+                bytes.set(writeCaret    , 0); // B
+                bytes.set(writeCaret + 1, 0); // G
+                bytes.set(writeCaret + 2, 0); // R
+                bytes.set(writeCaret + 3, 0); // A
+                
+                if (++x == frame.width)
+                {
+                  x = 0;
+                  writeCaret += lineSkip;
+                }
+                else writeCaret += 4;
+              }
+            default:
+              for (i in 0...pixels.length)
+              {
+                var index:Int = pixels.get(i) * 3;
+                if (transparentIndex != index) // Render only if pixel non-transparent
+                {
+                  bytes.set(writeCaret    , ct.get(index + 2)); // B
+                  bytes.set(writeCaret + 1, ct.get(index + 1)); // G
+                  bytes.set(writeCaret + 2, ct.get(index    )); // R
+                  bytes.set(writeCaret + 3, 0xFF);              // A
+                }
+                
+                if (++x == frame.width)
+                {
+                  x = 0;
+                  writeCaret += lineSkip;
+                }
+                else writeCaret += 4;
+              }
+          }
+          
+          if (frameCaret == frameIndex) return bytes;
+          frameCaret++;
+          gce = null;
+        default:
+      }
+    }
+    
+    return bytes;
+  }
+  
+  public static function buildFrameFromTrueColor(pixels:Bytes, width:Int, height:Int):Void
+  {
+    
+  }
+  
+  public static function loopCount(data:Data):Int
+  {
+    var frames:Int = 0;
+    for (block in data.blocks)
+    {
+      switch(block)
+      {
+        case Block.BExtension(Extension.EApplicationExtension(ApplicationExtension.AENetscapeLooping(loops))): return loops;
+        default :
+      }
+    }
+    return frames;
+  }
+  
+  private static var LN2:Float = Math.log(2);
+  @:noCompletion public static inline function log2(val:Float):Float
+  {
+    return Math.log(val) / LN2;
+  }
 }

--- a/format/gif/Tools.hx
+++ b/format/gif/Tools.hx
@@ -5,12 +5,14 @@ import haxe.io.Bytes;
 import haxe.io.BytesData;
 
 /**
- * ...
+ * Tools for gif data.
  * @author Yanrishatum
  */
 class Tools
 {
-
+  /**
+   * Returns amount of frames in Gif data.
+   */
   public static function framesCount(data:Data):Int
   {
     var frames:Int = 0;
@@ -26,34 +28,46 @@ class Tools
     return frames;
   }
   
-  public static function frameAtIndex(data:Data, frameIndex:Int):Frame
+  /**
+   * Returns frame at given index.
+   * @param data Gif data.
+   * @param frameIndex Index of frame.
+   * @return Frame at given index or null, if there is no frame at that index.
+   */
+  public static function frame(data:Data, frameIndex:Int):Frame
   {
-    var frames:Int = 0;
+    var counter:Int = 0;
     for (block in data.blocks)
     {
-      switch(block)
+      switch (block)
       {
         case Block.BFrame(frame):
-          if (frames == frameIndex) return frame;
-          frames++;
+          if (counter == frameIndex) return frame;
+          counter++;
         default :
       }
     }
     return null;
   }
   
-  public static function frameGraphicControlExtension(data:Data, frameIndex:Int):GraphicControlExtension
+  /**
+   * Returns Graphic Control extension for frame at given index.
+   * @param data Gif data.
+   * @param frameIndex Index of frame.
+   * @return GCE extension if it is exists for given frame, null otherwise.
+   */
+  public static function graphicControl(data:Data, frameIndex:Int):GraphicControlExtension
   {
-    var frames:Int = 0;
+    var counter:Int = 0;
     var gce:GraphicControlExtension = null;
     for (block in data.blocks)
     {
       switch (block)
       {
         case Block.BFrame(frame):
-          if (frames == frameIndex) return gce;
+          if (counter == frameIndex) return gce;
           gce = null;
-          frames++;
+          counter++;
         case Block.BExtension(Extension.EGraphicControl(g)):
           gce = g;
         default :
@@ -62,6 +76,17 @@ class Tools
     return null;
   }
   
+  //==========================================================
+  // Extracting.
+  //==========================================================
+  
+  /**
+   * Extracts frame pixel data in Blue-Green-Red-Alpha pixel format.
+   * This function extracts only exact frame and does put previous frame pixel data into resulting Bytes. Note that frame size may not equal to Gif logical screen size.
+   * @param data Gif data.
+   * @param frameIndex Frame index.
+   * @return BGRA pixel data with dimensions equals to specified Frame size. If frame does not present in Gif data returns null.
+   */
   public static function extractBGRA(data:Data, frameIndex:Int):Bytes
   {
     var gce:GraphicControlExtension = null;
@@ -106,6 +131,13 @@ class Tools
     return null;
   }
   
+  /**
+   * Extracts frame pixel data in Red-Green-Blue-Alpha pixel format.
+   * This function extracts only exact frame and does put previous frame pixel data into resulting Bytes. Note that frame size may not equal to Gif logical screen size.
+   * @param data Gif data.
+   * @param frameIndex Frame index.
+   * @return RGBA pixel data with dimensions equals to specified Frame size. If frame does not present in Gif data returns null.
+   */
   public static function extractRGBA(data:Data, frameIndex:Int):Bytes
   {
     var gce:GraphicControlExtension = null;
@@ -150,6 +182,13 @@ class Tools
     return null;
   }
   
+  /**
+   * Extracts full Gif pixel data to specified frame in Blue-Green-Red-Alpha pixel format.
+   * This functions returns full representation of frame including rendering of all other frames before.
+   * @param data Gif data.
+   * @param frameIndex Frame index.
+   * @return BGRA pixel data with dimensions equals to Gif logical screen with full pixel data of Gif image at specified frame.
+   */
   public static function extractFullBGRA(data:Data, frameIndex:Int):Bytes
   {
     var gce:GraphicControlExtension = null;
@@ -229,14 +268,100 @@ class Tools
     return bytes;
   }
   
-  public static function buildFrameFromTrueColor(pixels:Bytes, width:Int, height:Int):Void
+  /**
+   * Extracts full Gif pixel data to specified frame in Red-Green-Blue-Alpha pixel format.
+   * This functions returns full representation of frame including rendering of all other frames before.
+   * @param data Gif data.
+   * @param frameIndex Frame index.
+   * @return RGBA pixel data with dimensions equals to Gif logical screen with full pixel data of Gif image at specified frame.
+   */
+  public static function extractFullRGBA(data:Data, frameIndex:Int):Bytes
   {
+    var gce:GraphicControlExtension = null;
+    var frameCaret:Int = 0;
     
+    var bytes:Bytes = Bytes.alloc(data.logicalScreenDescriptor.width* data.logicalScreenDescriptor.height * 4);
+    
+    for (block in data.blocks)
+    {
+      switch (block)
+      {
+        case Block.BExtension(ext):
+          switch(ext)
+          {
+            case Extension.EGraphicControl(g):
+              gce = g;
+            default:
+          }
+        case Block.BFrame(frame):
+          var ct:Bytes = frame.localColorTable ? frame.colorTable : data.globalColorTable;
+          if (ct == null) throw "Frame does not have a color table!";
+          var transparentIndex:Int = gce != null && gce.hasTransparentColor ? gce.transparentIndex * 3 : -1;
+          var pixels:Bytes = frame.pixels;
+          var x:Int = 0;
+          var writeCaret:Int = (frame.y * data.logicalScreenDescriptor.width + frame.x) * 4;
+          var lineSkip:Int = (data.logicalScreenDescriptor.width - frame.width) * 4 + 4;
+          
+          var disposalMethod:DisposalMethod = frameCaret != frameIndex && gce != null ? gce.disposalMethod : DisposalMethod.NO_ACTION;
+          
+          switch (disposalMethod)
+          {
+            case DisposalMethod.RENDER_PREVIOUS:
+              // Do not render frame at all
+            case DisposalMethod.FILL_BACKGROUND:
+              for (i in 0...pixels.length)
+              {
+                bytes.set(writeCaret    , 0); // R
+                bytes.set(writeCaret + 1, 0); // G
+                bytes.set(writeCaret + 2, 0); // B
+                bytes.set(writeCaret + 3, 0); // A
+                
+                if (++x == frame.width)
+                {
+                  x = 0;
+                  writeCaret += lineSkip;
+                }
+                else writeCaret += 4;
+              }
+            default:
+              for (i in 0...pixels.length)
+              {
+                var index:Int = pixels.get(i) * 3;
+                if (transparentIndex != index) // Render only if pixel non-transparent
+                {
+                  bytes.set(writeCaret    , ct.get(index    )); // R
+                  bytes.set(writeCaret + 1, ct.get(index + 1)); // G
+                  bytes.set(writeCaret + 2, ct.get(index + 2)); // B
+                  bytes.set(writeCaret + 3, 0xFF);              // A
+                }
+                
+                if (++x == frame.width)
+                {
+                  x = 0;
+                  writeCaret += lineSkip;
+                }
+                else writeCaret += 4;
+              }
+          }
+          
+          if (frameCaret == frameIndex) return bytes;
+          frameCaret++;
+          gce = null;
+        default:
+      }
+    }
+    
+    return bytes;
   }
   
+  /**
+   * Returns amount of animation repeats stored in Gif data.
+   * This is link to Netscape Looping application extension. If this extension does not present amount of loops equals to 1.
+   * @param data Gif data.
+   * @return Amount of animation repeats. Zero equals to infinite amount of repeats.
+   */
   public static function loopCount(data:Data):Int
   {
-    var frames:Int = 0;
     for (block in data.blocks)
     {
       switch(block)
@@ -245,8 +370,17 @@ class Tools
         default :
       }
     }
-    return frames;
+    return 1;
   }
+  
+  //==========================================================
+  // In-Dev writer tools.
+  //==========================================================
+  
+  //public static function buildFrameFromTrueColor(pixels:Bytes, width:Int, height:Int):Void
+  //{
+    //
+  //}
   
   private static var LN2:Float = Math.log(2);
   @:noCompletion public static inline function log2(val:Float):Float

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,6 +4,6 @@
 	"license" : "BSD",
 	"contributors" : ["ncannasse"],
 	"description" : "A Haxe Library for supporting different file formats.",
-	"version" : "3.1.1",
+	"version" : "3.1.2",
 	"releasenote" : "See CHANGES.txt"
 }

--- a/tests/gif/Test.hx
+++ b/tests/gif/Test.hx
@@ -15,7 +15,7 @@ class Test
     var frames:Int = Tools.framesCount(data);
     for (i in 0...frames)
     {
-      var frame:Frame = Tools.frameAtIndex(data, i);
+      var frame:Frame = Tools.frame(data, i);
       var bytes:Bytes = Tools.extractBGRA(data, i);
       var pngData:format.png.Data = format.png.Tools.build32BGRA(frame.width, frame.height, bytes);
       var out = File.write("frame_" + i + ".png", true);

--- a/tests/gif/Test.hx
+++ b/tests/gif/Test.hx
@@ -1,0 +1,28 @@
+import haxe.io.Bytes;
+import sys.io.File;
+import format.gif.Reader;
+import format.gif.Data;
+import format.gif.Tools;
+import format.png.Writer;
+
+class Test
+{
+	static function main()
+  {
+    var i = File.read("read.gif", true);
+    var data:Data = new Reader(i).read();
+    
+    var frames:Int = Tools.framesCount(data);
+    for (i in 0...frames)
+    {
+      var frame:Frame = Tools.frameAtIndex(data, i);
+      var bytes:Bytes = Tools.extractBGRA(data, i);
+      var pngData:format.png.Data = format.png.Tools.build32BGRA(frame.width, frame.height, bytes);
+      var out = File.write("frame_" + i + ".png", true);
+      new Writer(out).write(pngData);
+      out.flush();
+      out.close();
+    }
+	}
+
+}

--- a/tests/gif/project.hxml
+++ b/tests/gif/project.hxml
@@ -1,0 +1,4 @@
+# hxgif
+-neko hxgif.n
+-main Test
+-cp ../..

--- a/tests/gif/run.bat
+++ b/tests/gif/run.bat
@@ -1,0 +1,3 @@
+@echo off
+neko hxgif
+pause


### PR DESCRIPTION
As it says in title. Gif file support. Contains `Tools` to ease `format.gif.Data` usage, such as:  
* Recieving amount of frames in total.  
* Getting exact frame.  
* Getting GraphicControl extension bounded to frame index.
* Getting loops count (Netscape 2.0 Looping application extension)

GraphicControl extension are not linked with Frame because it's separated parts of Gif file data chunks. Plus GC only featured in 89a Gif specification (as well as most of the others data types) and must be ignored for 87a version.