### PR TITLE
Substituted typedef with class

### DIFF
--- a/format/agal/Data.hx
+++ b/format/agal/Data.hx
@@ -73,11 +73,38 @@ enum Opcode {
 	OSne( dst : Reg, a : Reg, b : Reg );
 }
 
-typedef Reg = {
-	var t : RegType;
-	var index : Int;
-	var swiz : Swizzle;
-	var access : Null<{ t : RegType, comp : C, offset : Int }>;
+class RegAccess {
+	public var t : RegType;
+	public var comp : C;
+	public var offset : Int;
+	
+	public inline function new(t,c,o) {
+		this.t = t;
+		comp = c;
+		offset = o;
+	}
+	
+	public inline function clone() {
+		return new RegAccess(t, comp, offset);
+	}
+}
+
+class Reg {
+	public var t 		: RegType;
+	public var index 	: Int;
+	public var swiz 	: Swizzle;
+	public var access 	: Null<RegAccess>;
+	
+	public inline function new(t,i,s,?a) {
+		this.t = t;
+		index = i;
+		swiz = s;
+		access = a;
+	}
+	
+	public inline function clone() {
+		return new Reg(t, index, swiz, access);
+	}
 }
 
 typedef Swizzle = Null<Array<C>>; // length 1-4

--- a/format/agal/Tools.hx
+++ b/format/agal/Tools.hx
@@ -34,11 +34,11 @@ class Tools {
 		return 8;
 	}
 
-	public static function getMaxOps( fragment : Bool, version = 1 ) {
+	public static function getMaxOps( fragment : Bool, ?version = 1 ) {
 		return version == 1 ? 200 : 1024;
 	}
 
-	public static function getProps( r : Data.RegType, fragment : Bool, version = 1 ) {
+	public static function getProps( r : Data.RegType, fragment : Bool, ?version = 1 ) {
 		return switch( r ) {
 		case RAttr: if( fragment ) { read : false, write : false, count : 0 } else { read : true, write : false, count : 8 };
 		case RConst: { read : true, write : false, count : version == 1 ? (fragment ? 28 : 128) : (fragment ? 64 : 250) };
@@ -66,7 +66,7 @@ class Tools {
 		if( str == "o0" ) str = "out";
 		var acc = r.access;
 		if( acc != null )
-			str = regStr( { t : acc.t, index : acc.offset, access : null, swiz : null } ) + "[" + str + "." + Std.string(acc.comp).toLowerCase() + "]";
+			str = regStr( new Data.Reg(  acc.t, acc.offset,  null,  null ) ) + "[" + str + "." + Std.string(acc.comp).toLowerCase() + "]";
 		if( r.swiz != null ) {
 			str += ".";
 			for( s in r.swiz )


### PR DESCRIPTION
Typedefed are a heavy burden even on browser desktops :

In my case with 6 shader creations in one frame and 200 shader property change, we jumped from 150ms to 3ms by the fix in hxsl.

In general typedef are good for prototyping but they cause tremendous problems at runtime.
In hxsl you will have to substitute the Reflect.copy calls to a manual .clone()

- Reflect.copy generates xml parsing and garbage generation because the reflective accesses generates lot of strings
- The typedefs members calls generates strings.
- Flash is very bad at gc of medium sized objects.
- the "class" ification caused a lot of the temp value to go on the stack

This all cause lot of gc pressure and in a Browser environnement, the memory allocator of flash is dependent on the browser's allocation speed which changes a lot about performances of allocations. Allocations are generally slow, but in that case they became just overweight.

The migration of h3d hxsl took only 30 minutes with full testing, it a little pain but it is really a good call.


