### PR TITLE
allow writing null (optional) indexes

### DIFF
--- a/format/abc/Writer.hx
+++ b/format/abc/Writer.hx
@@ -81,7 +81,9 @@ class Writer {
 
 	function writeIndex( i : Index<Dynamic> ) {
 		switch( i ) {
-		case Idx(n): writeInt(n);
+			// i may be null, see Reader.readIndexOpt
+			case null: writeInt(0); 
+			case Idx(n): writeInt(n);
 		}
 	}
 


### PR DESCRIPTION
as per `format.abc.Reader.readIndexOpt`, indexes can be `null`, in which case their value is `0`