### PR TITLE
[swf] fixed overflow due to advance being signed

### DIFF
--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -1123,7 +1123,7 @@ class Writer {
 			o.writeInt16(data.layout.leading);
 
 			for (g in data.layout.glyphs)
-				o.writeUInt16(g.advance > 0xFFFF ? 0xFFFF : g.advance);
+				o.writeInt16(g.advance > 0xFFFF ? 0xFFFF : g.advance);
 
 			for(g in data.layout.glyphs)
 				writeRect(g.bounds);


### PR DESCRIPTION
This is symetric to the `Reader` implementation (`readInt16`)