### PR TITLE
Basic TGA/TARGA file format support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Currently supported formats are :
   * TGZ (TAR+GZ Archive)
   * WAV (Raw sound)
   * ZIP (Compressed Archive)
-  * GIF (Image file format - reader only atm)
+  * GIF (Image file format - writer don't have tools)
+  * TGA (TARGA Image file format; Reader/Writer does not support developer data chunk; Writer does not support RLE encoding)
 
 Installation
 ============

--- a/format/tga/Data.hx
+++ b/format/tga/Data.hx
@@ -1,0 +1,118 @@
+package format.tga;
+import haxe.ds.Vector;
+
+typedef Header =
+{
+  /**
+   * Indicated type of color map.
+   * 0 = no color map present.
+   * 1 = color map included.
+   * 2-127 is reserved by Truevision
+   * 128-255 may be used by app developers.
+   */
+  var colorMapType:Int;
+  /** Image data type. */
+  var imageType:ImageType;
+  // Color map specification
+  /**
+   * Index of the first color map entry. Index refers to the starting entry in
+   * loading the color map.
+   */
+  var colorMapFirstIndex:Int;
+  /** Total number of color map entries included. */
+  var colorMapLength:Int;
+  /**
+   * Establishes the number of bits per entry. Typically 15, 16, 24 or 32-bit
+   * values are used.
+   */
+  var colorMapEntrySize:Int;
+  
+  // Image specification
+  /**
+   * These bytes specify the absolute horizontal coordinate for the lower left
+   * corner of the image as it is positioned on a display device having an
+   * origin at the lower left of the screen (e.g., the TARGA series).
+   */
+  var xOrigin:Int;
+  /**
+   * These bytes specify the absolute vertical coordinate for the lower left
+   * corner of the image as it is positioned on a display device having an
+   * origin at the lower left of the screen (e.g., the TARGA series).
+   */
+  var yOrigin:Int;
+  /** This field specifies the width of the image in pixels. */
+  var width:Int;
+  /** This field specifies the height of the image in pixels. */
+  var height:Int;
+  /**
+   * This field indicates the number of bits per pixel. This number includes
+   * the Attribute or Alpha channel bits. Common values are 8, 16, 24 and
+   * 32 but other pixel depths could be used.
+   */
+  var bitsPerPixel:Int;
+  /**
+   * the number of attribute bits per
+   * pixel. In the case of the TrueVista, these bits
+   * indicate the number of bits per pixel which are
+   * designated as Alpha Channel bits. For the ICB
+   * and TARGA products, these bits indicate the
+   * number of overlay bits available per pixel.
+   */
+  var alphaChannelBits:Int;
+  var imageOrigin:ImageOrigin;
+  
+  /*
+   * There is probably additional flag adding interlaced encoding?
+   * 
+   * Bits 7-6 - Data storage interleaving flag. 
+   * 00 = non-interleaved.
+   * 01 = two-way (even/odd) interleaving.
+   * 10 = four way interleaving.
+   * 11 = reserved.
+   */
+}
+
+enum ImageOrigin
+{
+  BottomLeft;
+  BottomRight;
+  TopLeft;
+  TopRight;
+}
+
+enum ImageType
+{
+  /** There is no image data present */
+  NoImage;                   // 0
+  /** Uncompressed image with color-map usage */
+  UncompressedColorMapped;   // 1
+  /** True-color uncompressed image */
+  UncompressedTrueColor;     // 2
+  /** Black-and-White uncompresed image */
+  UncompressedBlackAndWhite; // 3
+  /** Run-length encoded image with color-map usage */
+  RunLengthColorMapped;      // 9
+  /** Run-length encoded true-color image */
+  RunLengthTrueColor;        // 10
+  /** Run-length encoded black-and-white image */
+  RunLengthBlackAndWhite;    // 11
+  /** Unknown type */
+  Unknown(type:Int);
+  
+  /*
+   * Found also:
+   * 32  -  Compressed color-mapped data, using Huffman, Delta, and
+   *        runlength encoding.
+   * 33  -  Compressed color-mapped data, using Huffman, Delta, and
+   *        runlength encoding.  4-pass quadtree-type process. 
+   * */
+}
+
+typedef Data =
+{
+  var header:Header;
+  var imageId:String;
+  var colorMapData:Vector<Int>;
+  var imageData:Vector<Int>;
+  var developerData:Dynamic; // Not supported ATM
+};

--- a/format/tga/Reader.hx
+++ b/format/tga/Reader.hx
@@ -1,0 +1,352 @@
+package format.tga;
+import format.tga.Data;
+import haxe.ds.Vector;
+import haxe.io.Input;
+
+/**
+ * ...
+ * @author Yanrishatum
+ */
+class Reader
+{
+
+  private var i:Input;
+  
+  public function new(i:Input) 
+  {
+    this.i = i;
+    i.bigEndian = false;
+  }
+  
+  public function read():Data
+  {
+    var idLength:Int = i.readByte();
+    var header:Header = readHeader();
+    var id:String = idLength == 0 ? "" : i.readString(idLength);
+    var colorMap:Vector<Int> = readColorMapData(header);
+    
+    return {
+      header: header,
+      imageId: id,
+      colorMapData: colorMap,
+      imageData: readImageData(header, colorMap),
+      developerData: null
+    };
+  }
+  
+  private function readHeader():Header
+  {
+    var colorMapType:Int = i.readByte();
+    var dataType:ImageType;
+    var dataId:Int = i.readByte();
+    switch (dataId)
+    {
+      case 0:
+        dataType = ImageType.NoImage;
+      case 1:
+        dataType = ImageType.UncompressedColorMapped;
+      case 2:
+        dataType = ImageType.UncompressedTrueColor;
+      case 3:
+        dataType = ImageType.UncompressedBlackAndWhite;
+      case 9:
+        dataType = ImageType.RunLengthColorMapped;
+      case 10:
+        dataType = ImageType.RunLengthTrueColor;
+      case 11:
+        dataType = ImageType.RunLengthBlackAndWhite;
+      default:
+        dataType = ImageType.Unknown(dataId);
+    }
+    
+    var colorMapOrigin:Int = i.readInt16();
+    var colorMapLength:Int = i.readInt16();
+    var colorMapDepth:Int = i.readByte();
+    
+    var xOrigin:Int = i.readInt16();
+    var yOrigin:Int = i.readInt16();
+    var width:Int = i.readInt16();
+    var height:Int = i.readInt16();
+    var depth:Int = i.readByte();
+    var descriptor:Int = i.readByte();
+    var origin:ImageOrigin;
+    
+    switch ((descriptor & 0x30))
+    {
+      case 0x30: origin = ImageOrigin.TopRight;
+      case 0x20: origin = ImageOrigin.TopLeft;
+      case 0x10: origin = ImageOrigin.BottomRight;
+      default: origin = ImageOrigin.BottomLeft;
+    }
+    
+    return
+    {
+      colorMapType: colorMapType,
+      imageType: dataType,
+      
+      colorMapFirstIndex: colorMapOrigin,
+      colorMapLength: colorMapLength,
+      colorMapEntrySize: colorMapDepth,
+      
+      xOrigin: xOrigin,
+      yOrigin: yOrigin,
+      width: width,
+      height: height,
+      bitsPerPixel: depth,
+      
+      alphaChannelBits: descriptor & 0xf,
+      imageOrigin: origin
+    };
+  }
+  
+  // Currently supports only color maps with 
+  private function readColorMapData(header:Header):Vector<Int>
+  {
+    if (header.colorMapType == 0) return null;
+    return readPixels(header.colorMapEntrySize, header.colorMapLength, header.alphaChannelBits, false);
+  }
+  
+  private function readImageData(header:Header, colorMap:Vector<Int>):Vector<Int>
+  {
+    switch (header.imageType)
+    {
+      case ImageType.NoImage:
+        return null;
+        
+      case ImageType.UncompressedTrueColor:
+        return readPixels(header.bitsPerPixel, header.width * header.height, header.alphaChannelBits, false);
+      case ImageType.RunLengthTrueColor:
+        return readPixels(header.bitsPerPixel, header.width * header.height, header.alphaChannelBits, true);
+        
+      case ImageType.UncompressedBlackAndWhite: // This one a bit tricky
+        return readMono(header.bitsPerPixel, header.width * header.height, header.alphaChannelBits, false);
+      case ImageType.RunLengthBlackAndWhite:
+        return readMono(header.bitsPerPixel, header.width * header.height, header.alphaChannelBits, true);
+        
+      case ImageType.UncompressedColorMapped:
+        return readIndexes(header.bitsPerPixel, header.width * header.height, colorMap, header.colorMapFirstIndex, false);
+      case ImageType.RunLengthColorMapped:
+        return readIndexes(header.bitsPerPixel, header.width * header.height, colorMap, header.colorMapFirstIndex, true);
+        
+      default:
+        throw "Unsupported image data type!";
+    }
+  }
+  
+  private function readPixels(bitsPerPixel:Int, amount:Int, alphaChannelBits:Int, rle:Bool):Vector<Int>
+  {
+    var list:Vector<Int> = new Vector(amount);
+    // Total length of color map data
+    var alpha:Bool = alphaChannelBits != 0;
+    
+    var bitFieldSize:Int = Std.int(bitsPerPixel / 3);
+    if (bitFieldSize > 8) bitFieldSize = 8;
+    
+    var parsePixel:Int->Bool->Int;
+    var readEntry:Void->Int;
+    switch (bitsPerPixel)
+    {
+      case 8:
+        readEntry = i.readByte;
+        parsePixel = parsePixel1;
+      case 16:
+        readEntry = i.readUInt16;
+        parsePixel = parsePixel2;
+      case 24:
+        readEntry = i.readUInt24;
+        parsePixel = parsePixel3;
+      case 32:
+        readEntry = i.readInt32;
+        parsePixel = parsePixel4;
+      default:
+        throw "Unsupported bits per pixels amount!";
+    }
+    
+    if (rle)
+    {
+      var rleChunk:Int;
+      var i:Int = 0;
+      while (i < amount)
+      {
+        rleChunk = this.i.readByte();
+        if ((rleChunk & 0x80) != 0) // RLE
+        {
+          rleChunk = rleChunk & 0x7F;
+          var pixel:Int = parsePixel(readEntry(), alpha);
+          while (rleChunk >= 0)
+          {
+            list[i++] = pixel;
+            rleChunk--;
+          }
+        }
+        else // Raw
+        {
+          rleChunk = rleChunk & 0x7F;
+          while (rleChunk >= 0)
+          {
+            list[i++] = parsePixel(readEntry(), alpha);
+            rleChunk--;
+          }
+        }
+      }
+    }
+    else
+    {
+      for (i in 0...amount)
+      {
+        list[i] = parsePixel(readEntry(), alpha);
+      }
+      
+    }
+    
+    
+    return list;
+  }
+  
+  private function readMono(bitsPerPixel:Int, amount:Int, alphaChannelBits:Int, rle:Bool):Vector<Int>
+  {
+    var list:Vector<Int> = new Vector(amount);
+    // Total length of color map data
+    var alpha:Bool = alphaChannelBits != 0;
+    
+    var parsePixel:Int->Bool->Int;
+    var readEntry:Void->Int;
+    switch (bitsPerPixel)
+    {
+      case 8:
+        readEntry = i.readByte;
+        parsePixel = parsePixel1;
+      case 16:
+        readEntry = i.readUInt16;
+        parsePixel = parsePixelGreyAlpha;
+      default:
+        throw "Unsupported bits per pixels amount!";
+    }
+    
+    if (rle)
+    {
+      var rleChunk:Int;
+      var i:Int = 0;
+      while (i < amount)
+      {
+        rleChunk = this.i.readByte();
+        if ((rleChunk & 0x80) != 0) // RLE
+        {
+          rleChunk = rleChunk & 0x7F;
+          var pixel:Int = parsePixel(readEntry(), alpha);
+          while (rleChunk >= 0)
+          {
+            list[i++] = pixel;
+            rleChunk--;
+          }
+        }
+        else // Raw
+        {
+          rleChunk = rleChunk & 0x7F;
+          while (rleChunk >= 0)
+          {
+            list[i++] = parsePixel(readEntry(), alpha);
+            rleChunk--;
+          }
+        }
+      }
+    }
+    else
+    {
+      for (i in 0...amount)
+      {
+        list[i] = parsePixel(readEntry(), alpha);
+      }
+    }
+    
+    
+    return list;
+  }
+  
+  private function readIndexes(bitsPerPixel:Int, amount:Int, colorMap:Vector<Int>, offset:Int, rle:Bool):Vector<Int>
+  {
+    var list:Vector<Int> = new Vector(amount);
+    
+    var readEntry:Void->Int;
+    switch (bitsPerPixel)
+    {
+      case 8:
+        readEntry = i.readByte;
+      case 16:
+        readEntry = i.readUInt16;
+      case 24:
+        readEntry = i.readUInt24;
+      case 32:
+        readEntry = i.readInt32;
+      default:
+        throw "Unsupported bits per pixels amount!";
+    }
+    
+    if (rle)
+    {
+      var i:Int = 0;
+      var rleChunk:Int;
+      while (i < amount)
+      {
+        rleChunk = this.i.readByte();
+        if ((rleChunk & 0x80) != 0) // RLE
+        {
+          rleChunk = rleChunk & 0x7F;
+          var pixel:Int = colorMap[offset + readEntry()];
+          while (rleChunk >= 0)
+          {
+            list[i++] = pixel;
+            rleChunk--;
+          }
+        }
+        else // RAW
+        {
+          rleChunk = rleChunk & 0x7F;
+          while (rleChunk >= 0)
+          {
+            list[i++] = colorMap[offset + readEntry()];
+            rleChunk--;
+          }
+        }
+      }
+    }
+    else
+    {
+      for (i in 0...amount)
+      {
+        list[i] = colorMap[offset + readEntry()];
+      }
+    }
+    
+    return list;
+  }
+  
+  private function parsePixel1(value:Int, alpha:Bool):Int
+  {
+    return (value << 16) | (value << 8) | value;
+  }
+  
+  private function parsePixelGreyAlpha(value:Int, alpha:Bool):Int
+  {
+    return (alpha ? (value & 0xff00) << 16 : 0) | parsePixel1(value & 0xff, false);
+  }
+  
+  private function parsePixel2(value:Int, alpha:Bool):Int
+  {
+    return (alpha ? ((value & 0x8000) == 1 ? 0xff000000 : 0) : 0) | // A
+          Std.int(((value & 0x7C00) >> 10) / 0x1F * 0xff) << 16 | // R
+          Std.int(((value & 0x3E0) >> 5) / 0x1F * 0xff) << 8 | // G
+          Std.int((value & 0x1F) / 0x1F * 0xff); // B
+  }
+  
+  private function parsePixel3(value:Int, alpha:Bool):Int
+  {
+    return value;
+  }
+  
+  private function parsePixel4(value:Int, alpha:Bool):Int
+  {
+    return value;
+  }
+  
+}

--- a/format/tga/Tools.hx
+++ b/format/tga/Tools.hx
@@ -1,0 +1,113 @@
+package format.tga;
+import haxe.io.Bytes;
+import format.tga.Data;
+
+/**
+ * ...
+ * @author Yanrishatum
+ */
+class Tools
+{
+
+  /**
+   * Extracts BGRA pixel data from TGA file.  
+   * If `extractAlpha` is true, alpha channel will be applied to image, mostly resulting in completely transparent image.  
+   * Otherwise alpha will be forced to 0xFF.  
+   * If image does not contain image data, 0-filled array returned.
+   */
+  public static function extract32(data:Data, extractAlpha:Bool):Bytes
+  {
+    var pixels:Bytes = Bytes.alloc(data.header.width * data.header.height * 4);
+    if (data.imageData == null) return pixels;
+    var i:Int = 0;
+    var alphaOverride:Int = extractAlpha ? 0 : 0xff;
+    switch (data.header.imageOrigin)
+    {
+      case ImageOrigin.TopLeft:
+        for (pixel in data.imageData)
+        {
+          pixels.set(i    , (pixel) & 0xff);
+          pixels.set(i + 1, (pixel >> 8) & 0xff);
+          pixels.set(i + 2, (pixel >> 16) & 0xff);
+          pixels.set(i + 3, ((pixel >> 24) & 0xff) | alphaOverride);
+          i += 4;
+        }
+      case ImageOrigin.BottomLeft:
+        var j:Int = 0;
+        var y:Int = data.header.height - 1;
+        while(y >= 0)
+        {
+          i = y * data.header.width * 4;
+          y--;
+          for (x in 0...data.header.width)
+          {
+            var pixel:Int = data.imageData[j++];
+            pixels.set(i    , (pixel) & 0xff);
+            pixels.set(i + 1, (pixel >> 8) & 0xff);
+            pixels.set(i + 2, (pixel >> 16) & 0xff);
+            pixels.set(i + 3, ((pixel >> 24) & 0xff) | alphaOverride);
+            i += 4;
+          }
+        }
+      default:
+        throw "This origin does not supported";
+    }
+    return pixels;
+  }
+  
+  /**
+   * Extracts alpha channel from TGA file.  
+   * If image does not contain image data, 0-filled array returned.
+   */
+  public static function extractAlpha(data:Data):Bytes
+  {
+    return extractChannel(data, 24);
+  }
+  
+  /**
+   * Extracts grey channel from TGA file.  
+   * If image does not contains image data 0-filled array returned.  
+   * If image is not black-and-white, error thrown.
+   */
+  public static function extractGrey(data:Data):Bytes
+  {
+    if (data.header.imageType != ImageType.RunLengthBlackAndWhite && data.header.imageType != ImageType.UncompressedBlackAndWhite)
+    {
+      throw "This is not B&W image!";
+    }
+    return extractChannel(data, 0);
+  }
+  
+  private static function extractChannel(data:Data, offset:Int):Bytes
+  {
+    var pixels:Bytes = Bytes.alloc(data.header.width * data.header.height);
+    if (data.imageData == null) return pixels;
+    
+    var i:Int = 0;
+    
+    switch (data.header.imageOrigin)
+    {
+      case ImageOrigin.TopLeft:
+        for (pixel in data.imageData)
+        {
+          pixels.set(i++, (pixel >> offset) & 0xff);
+        }
+      case ImageOrigin.BottomLeft:
+        var j:Int = 0;
+        var y:Int = data.header.height - 1;
+        while(y >= 0)
+        {
+          i = y * data.header.width;
+          y--;
+          for (x in 0...data.header.width)
+          {
+            pixels.set(i++, (data.imageData[j++] >> offset) & 0xff);
+          }
+        }
+      default:
+        throw "This origin does not supported";
+    }
+    return pixels;
+  }
+  
+}

--- a/format/tga/Writer.hx
+++ b/format/tga/Writer.hx
@@ -1,0 +1,221 @@
+package format.tga;
+import format.tga.Data;
+import haxe.ds.Vector;
+import haxe.io.Output;
+
+/**
+ * ...
+ * @author Yanrishatum
+ */
+class Writer
+{
+  
+  private var o:Output;
+
+  public function new(o:Output) 
+  {
+    this.o = o;
+  }
+  
+  public function write(data:Data):Void
+  {
+    writeHeader(data);
+    if (data.imageId != null) o.writeString(data.imageId);
+    switch (data.header.imageType)
+    {
+      case ImageType.NoImage:
+        writeColorMap(data);
+        
+      case ImageType.UncompressedColorMapped:
+        writeColorMap(data);
+        writeIndexes(data, false);
+      case ImageType.UncompressedTrueColor:
+        writeTrueColor(data, false);
+      case ImageType.UncompressedBlackAndWhite:
+        writeMono(data, false);
+      case ImageType.RunLengthColorMapped:
+        writeColorMap(data);
+        writeIndexes(data, true);
+      case ImageType.RunLengthTrueColor:
+        writeTrueColor(data, true);
+      case ImageType.RunLengthBlackAndWhite:
+        writeMono(data, true);
+        
+      default: 
+        throw "Unsupported image type";
+    }
+    
+  }
+  
+  private function writeTrueColor(data:Data, rle:Bool):Void
+  {
+    writePixels(data.imageData, data.header.bitsPerPixel, data.header.alphaChannelBits != 0, rle);
+  }
+  
+  private function writeColorMap(data:Data):Void
+  {
+    writePixels(data.colorMapData, data.header.colorMapEntrySize, data.header.alphaChannelBits != 0, false);
+  }
+  
+  private function writeIndexes(data:Data, rle:Bool):Void
+  {
+    var pal:Vector<Int> = data.colorMapData;
+    var pixels:Vector<Int> = data.imageData;
+    if (rle)
+    {
+      throw "Run-Length encoding does not supported yet";
+    }
+    else
+    {
+      var writeFunc:Int->Void;
+      switch (data.header.bitsPerPixel)
+      {
+        case 8:
+          writeFunc = o.writeByte;
+        case 24:
+          writeFunc = o.writeUInt24;
+        case 32:
+          writeFunc = o.writeInt32;
+        default:
+          throw "Unsupported bits per pixels amount";
+      }
+      
+      var i:Int = 0;
+      
+      inline function indexOf(val:Int):Int
+      {
+        var off:Int = 0;
+        while (off < pal.length)
+        {
+          if (pal[off] == val) break;
+          off++;
+        }
+        return off;
+      }
+      
+      while (i < pixels.length)
+      {
+        writeFunc(indexOf(pixels[i++]));
+      }
+    }
+  }
+  
+  private function writeMono(data:Data, rle:Bool):Void
+  {
+    var pixels:Vector<Int> = data.imageData;
+    if (rle)
+    {
+      throw "Run-Length encoding does not supported yet";
+    }
+    else
+    {
+      var alhpa:Bool = data.header.bitsPerPixel == 16;
+      
+      var i:Int = 0;
+      while (i < pixels.length)
+      {
+        var pix:Int = pixels[i++];
+        o.writeByte(pix & 0xff);
+        if (alhpa) o.writeByte((pix >> 24) & 0xff);
+      }
+    }
+  }
+  
+  private function writePixels(pixels:Vector<Int>, bitsPerPixel:Int, alpha:Bool, rle:Bool):Void
+  {
+    if (rle) throw "Run-Length encoding does not supported yet";
+    else
+    {
+      var writeFunc:Int->Void;
+      var encodeFunc:Int->Bool->Int;
+      switch (bitsPerPixel)
+      {
+        case 16:
+          writeFunc = o.writeUInt16;
+          encodeFunc = encode16;
+        case 24:
+          writeFunc = o.writeUInt24;
+          encodeFunc = encode24;
+        case 32:
+          writeFunc = o.writeInt32;
+          encodeFunc = encode32;
+        default:
+          throw "Unsupported bits per pixels amount";
+      }
+      
+      var i:Int = 0;
+      while (i < pixels.length)
+      {
+        writeFunc(encodeFunc(pixels[i++], alpha));
+      }
+    }
+  }
+  
+  private function encode16(color:Int, alpha:Bool):Int
+  {
+    return (alpha ? ((color & 0xff000000) != 0 ? 0x8000 : 0) : 0)  | // A
+           Std.int(((color & 0xff0000) >> 16) / 0xff * 0x1f) << 10 | // R
+           Std.int(((color & 0xff00) >> 8) / 0xff * 0x1f) << 5     | // G
+           Std.int((color & 0xff) / 0xff * 0x1f);                    // B
+  }
+  
+  private function encode24(color:Int, alpha:Bool):Int
+  {
+    return color & 0xffffff;
+  }
+  
+  private function encode32(color:Int, alpha:Bool):Int
+  {
+    return alpha ? color : color & 0xffffff;
+  }
+  
+  private function writeHeader(data:Data):Void
+  {
+    var h:Header = data.header;
+    o.writeByte(data.imageId != null ? data.imageId.length : 0);
+    o.writeByte(h.colorMapType);
+    switch (h.imageType)
+    {
+      case ImageType.NoImage:
+        o.writeByte(0);
+      case ImageType.UncompressedColorMapped:
+        o.writeByte(1);
+      case ImageType.UncompressedTrueColor:
+        o.writeByte(2);
+      case ImageType.UncompressedBlackAndWhite:
+        o.writeByte(3);
+      case ImageType.RunLengthColorMapped:
+        o.writeByte(9);
+      case ImageType.RunLengthTrueColor:
+        o.writeByte(10);
+      case ImageType.RunLengthBlackAndWhite:
+        o.writeByte(11);
+      case ImageType.Unknown(type):
+        o.writeByte(type);
+    }
+    
+    o.writeInt16(h.colorMapFirstIndex);
+    o.writeInt16(h.colorMapLength);
+    o.writeByte(h.colorMapEntrySize);
+    
+    o.writeInt16(h.xOrigin);
+    o.writeInt16(h.yOrigin);
+    o.writeInt16(h.width);
+    o.writeInt16(h.height);
+    o.writeByte(h.bitsPerPixel);
+    var descriptor:Int = h.alphaChannelBits;
+    switch (h.imageOrigin)
+    {
+      case ImageOrigin.BottomLeft:
+        // None
+      case ImageOrigin.BottomRight:
+        descriptor |= 0x10;
+      case ImageOrigin.TopLeft:
+        descriptor |= 0x20;
+      case ImageOrigin.TopRight:
+        descriptor |= 0x30;
+    }
+    o.writeByte(descriptor);
+  }
+  
+}

--- a/tests/tga/Test.hx
+++ b/tests/tga/Test.hx
@@ -1,0 +1,70 @@
+import haxe.io.Bytes;
+import sys.io.File;
+import sys.io.FileInput;
+import sys.io.FileOutput;
+class Test {
+
+	static function main() {
+    Sys.setCwd("samples");
+    // Simple B&W mode
+    Sys.println("Testing Black-and-white, [ubw8.tga, cbw8.tga]");
+    Sys.println(compare(["ubw8.tga", "cbw8.tga"], "bw.png", false));
+    
+    // Trickier, this one had another origin
+    Sys.println("Testing Black-and-white with bottom-left origin, [monochrome8_bottom_left.tga, monochrome8_bottom_left_rle.tga]");
+    Sys.println(compare(["monochrome8_bottom_left.tga", "monochrome8_bottom_left_rle.tga"], "monochrome8.png", false));
+    
+    // B&W + alpha channel included into data.
+    Sys.println("Testing B&W with alpha channel, [monochrome16_top_left.tga, monochrome16_top_left_rle.tga]");
+    Sys.println(compare(["monochrome16_top_left.tga", "monochrome16_top_left_rle.tga"], "monochrome16.png", true));
+    
+    // Simple truecolor
+    Sys.println("Testing TrueColor, [utc16.tga, utc24.tga, utc32.tga, ctc16.tga, ctc24.tga, ctc32.tga]");
+    Sys.println(compare(["utc16.tga", "utc24.tga", "utc32.tga", "ctc16.tga", "ctc24.tga", "ctc32.tga"], "color.png", false));
+    // Simple colormap
+    Sys.println("Testing ColorMap, [ucm8.tga, ccm8.tga]");
+    Sys.println(compare(["ucm8.tga", "ccm8.tga"], "color.png", false));
+    
+    // RGB is bascally same as lines
+    Sys.println("Testing RGB text TrueColor image [rgb24_bottom_left_rle.tga, rgb24_top_left.tga]");
+    Sys.println(compare(["rgb24_bottom_left_rle.tga", "rgb24_top_left.tga"], "rgb24.0.png", false));
+    // Don't ask me, why they are different in output, I don't know.
+    Sys.println("Testing RGB text ColorMap image [rgb24_top_left_colormap.tga]");
+    Sys.println(compare(["rgb24_top_left_colormap.tga"], "rgb24.1.png", false));
+    
+    // 32bpp with alpha channel + another origin
+    Sys.println("Testing RGB text TrueColor w/ alpha [rgb32_bottom_left.tga, rgb32_top_left_rle.tga]");
+    Sys.println(compare(["rgb32_bottom_left.tga", "rgb32_top_left_rle.tga"], "rgb32.0.png", true));
+    Sys.println("Testing RGB text ColorMap w/ alpha [rgb32_top_left_rle_colormap.tga]");
+    Sys.println(compare(["rgb32_top_left_rle_colormap.tga"], "rgb32.1.png", true));
+	}
+  
+  private static function compare(tga:Array<String>, reference:String, compareAlpha:Bool):Array<Bool>
+  {
+    var i:FileInput = File.read(reference);
+    var refPixels = format.png.Tools.extract32(new format.png.Reader(i).read());
+    i.close();
+    
+    var results:Array<Bool> = new Array();
+    
+    for (file in tga)
+    {
+      i = File.read(file);
+      var tgaData = new format.tga.Reader(i).read();
+      i.close();
+      var pixels:Bytes = format.tga.Tools.extract32(tgaData, compareAlpha);
+      var diff:Int = pixels.compare(refPixels);
+      results.push(diff == 0);
+      if (diff != 0)
+      {
+        var out:FileOutput = File.write(file + ".png");
+        new format.png.Writer(out).write(format.png.Tools.build32BGRA(tgaData.header.width, tgaData.header.height, pixels));
+        out.close();
+        trace(tgaData.header);
+        trace(diff);
+      }
+    }
+    return results;
+  }
+  
+}

--- a/tests/tga/project.hxml
+++ b/tests/tga/project.hxml
@@ -1,0 +1,4 @@
+# hxpng
+-neko hxtga.n
+-main Test
+-cp ../..

--- a/tests/tga/run.bat
+++ b/tests/tga/run.bat
@@ -1,0 +1,3 @@
+@echo off
+neko hxtga
+pause

--- a/tests/tga/samples/contents_source.txt
+++ b/tests/tga/samples/contents_source.txt
@@ -1,0 +1,2 @@
+Testing TGA files and comparation PNG's are taken from Github repo:
+https://github.com/ftrvxmtrx/tga


### PR DESCRIPTION
So, did it in a free time.
What's missing:
* Reader/Writer does not work with developer data chunk. It's not really essential for successfull pixel data decoding.
* Writer does not support RLE (Run-Length Endocing), only uncomprssed modes.
* Tools for building TGA Data from pixel-data.

Not sure about anything else essential.  
What supported:
* Image decoding of Uncompressed (U) and RLE (C) 16/24/32-bits-per-pixel TrueColor images.
* Image decoding of U/C 8-bit and 16-bpp (Alpha) Grayscale images.
* Image decoding of U/C indexed (ColorMaps) 8-bpp images.

This supposetly covers most of the possible variations.  

Backstory just for fun:
Friend did a few screenshots in WoW. By some reason it takes them in TGA format. Asked me to convert them. I was all like "okay, no problems". Just to find out that `format` does not support TGA and I need to open photoshop to convert them instead of just making writing small script that does it automatically! I had to fix that! And here I am. :D I may or may not finish TGA support. Depends on interest and time.