### PR TITLE
Repair decoding regression for PNG after tRNS pull request.

### DIFF
--- a/format/png/Tools.hx
+++ b/format/png/Tools.hx
@@ -558,6 +558,7 @@ class Tools {
 							r += 3;
 						}
 				case 1:
+					cr = cg = cb = ca = 0;
 					if( alpha )
 						for( x in 0...width ) {
 							cb += data.get(r + 2);	bgra.set(w++,cb);
@@ -593,7 +594,7 @@ class Tools {
 							r += 3;
 						}
 				case 3:
-					var cr = 0, cg = 0, cb = 0, ca = 0;
+					cr = cg = cb = ca = 0;
 					var stride = y == 0 ? 0 : width * 4 * flipY;
 					if( alpha )
 						for( x in 0...width ) {
@@ -613,7 +614,7 @@ class Tools {
 						}
 				case 4:
 					var stride = width * 4 * flipY;
-					var cr = 0, cg = 0, cb = 0, ca = 0;
+					cr = cg = cb = ca = 0;
 					if( alpha )
 						for( x in 0...width ) {
 							cb = (filter(bgra, x, y, stride, cb, w) + data.get(r + 2)) & 0xFF; bgra.set(w++, cb);


### PR DESCRIPTION
Apparently I broke decoding of truecolor images because of `cb, cg, cr, ca` was declared several times and had to be reset at each declaration place. I did not noticed that, resulting in both invalid tRNS support and broken decoding in general.
Sorry :)