### PR TITLE
AMF3 fixes

### DIFF
--- a/format/amf3/Tools.hx
+++ b/format/amf3/Tools.hx
@@ -186,7 +186,7 @@ class Tools {
 		if( a == null ) return null;
 		return switch( a ) {
 		case AMap(m):
-			var p = new Map<Value, Value>();
+			var p = new haxe.ds.EnumValueMap<Value, Value>();
 			for (f in m.keys())
 				p.set(decode(f), decode(m.get(f)));
 			p;


### PR DESCRIPTION
I received these fixes to resolve issues using DragonBones AMF3-encoded data.

This fixes a compile issue with the enum value map (here on Haxe 3.2.1) and also resolves incorrect decoding which resulted in the Reader detecting "AMF version 97" and other bugs due to wrong parsing. DragonBones samples now work properly here
