### PR TITLE
Fix buffer overflow when writing glyph advance

### DIFF
--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -1122,8 +1122,13 @@ class Writer {
 			o.writeInt16(data.layout.descent);
 			o.writeInt16(data.layout.leading);
 
-			for (g in data.layout.glyphs)
-				o.writeInt16(g.advance > 0xFFFF ? 0xFFFF : g.advance);
+			var advance;
+			for (g in data.layout.glyphs) {
+				advance = g.advance;
+				if (advance < -0x8000) advance = -0x8000;
+				if (advance > 0x7FFF) advance = 0x7FFF;
+				o.writeInt16(advance);
+			}
 
 			for(g in data.layout.glyphs)
 				writeRect(g.bounds);


### PR DESCRIPTION
A recent commit to haxefoundation/format changed this from `writeUInt16` to `writeInt16`, but this causes a crash when writing certain fonts.

This fix limits the advance size so that it will not result in a buffer overflow, fixing the embedding of common fonts such as the Ubuntu font
