### PR TITLE
Fix overflow in font advance

### DIFF
--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -1122,8 +1122,12 @@ class Writer {
 			o.writeInt16(data.layout.descent);
 			o.writeInt16(data.layout.leading);
 
-			for (g in data.layout.glyphs)
-				o.writeInt16(g.advance > 0xFFFF ? 0xFFFF : g.advance);
+			for (g in data.layout.glyphs) {
+				var advance = if(g.advance > 32767) 32767
+					else if(g.advance < -32768) -32768
+					else g.advance;
+				o.writeInt16(advance);
+			}
 
 			for(g in data.layout.glyphs)
 				writeRect(g.bounds);


### PR DESCRIPTION
f9dab7725eb6473ac6f855962f995e15bd4aa3c4 changed the writing of font advance values from unsigned to signed. This matches the [SWF specs (FontAdvanceTable, page 163)]([http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/swf/pdf/swf-file-format-spec.pdf), but the code doesn't clamp the signed value properly. This causes an overflow when writing fonts with large or small advance values. For example, try the [Noto Sans Symbols](https://www.google.com/get/noto/#sans-zsym) font.

This change clamps the advance value to the proper signed range.