### PR TITLE
Write glyph advance as unsigned instead of signed Int16

### DIFF
--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -1123,7 +1123,7 @@ class Writer {
 			o.writeInt16(data.layout.leading);
 
 			for (g in data.layout.glyphs) {
-				o.writeUInt16(g.advance & 0xFFFF);
+				o.writeUInt16(if( g.advance < 0 ) 0 else if( g.advance > 0xFFFF ) 0xFFFF else g.advance);
 			}
 
 			for(g in data.layout.glyphs)

--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -1123,10 +1123,7 @@ class Writer {
 			o.writeInt16(data.layout.leading);
 
 			for (g in data.layout.glyphs) {
-				var advance = if(g.advance > 32767) 32767
-					else if(g.advance < -32768) -32768
-					else g.advance;
-				o.writeInt16(advance);
+				o.writeUInt16(g.advance & 0xFFFF);
 			}
 
 			for(g in data.layout.glyphs)


### PR DESCRIPTION
Advance cannot be negative, but can be up to 65535

https://www.freetype.org/freetype2/docs/tutorial/step2.html