### PR TITLE
amf3 reader needs to return a signed integer

### DIFF
--- a/format/amf3/Reader.hx
+++ b/format/amf3/Reader.hx
@@ -303,7 +303,7 @@ class Reader {
 		if( c < 0x80 )
 			return c >> preShift;
 
-		var ret:UInt = (c & 0x7f) << 7;
+		var ret:Int = (c & 0x7f) << 7;
 		c = i.readByte() & 0xFF;
 		if( c < 0x80 )
 			return (ret | c) >> preShift;


### PR DESCRIPTION
@ncannasse sorry, somehow this one was not automatically included in the range of commits from our previous PR #60 which you just approved.

Plz consider this one part of that PR, as well. It fixes a one-character typo.