### PR TITLE
satisfy travis ci test build warning

### DIFF
--- a/format/amf3/Reader.hx
+++ b/format/amf3/Reader.hx
@@ -344,7 +344,7 @@ class Reader {
 			return AString( "" );  // 0x01 is empty string and is never sent by reference
 		// get the string characters
 		var u = new haxe.Utf8(len);
-		var c = 0, d = 0, j:UInt = 0, it = 0;
+		var c = 0, d = 0, j:Int = 0, it = 0;
 		while (j < len) {
 			c = i.readByte();
 			if (c < 0x80) {


### PR DESCRIPTION
at the request of @andyli  see (#65)

```
cd tests/all && haxe all.hxml
../../format/amf3/Reader.hx:348: characters 9-16 : Comparison of Int and UInt might lead to unexpected results with '#' will be ignored, and an empty message aborts the commit.
```