### PR TITLE
[as1] Fix writing zero-length catch blocks

### DIFF
--- a/format/as1/Writer.hx
+++ b/format/as1/Writer.hx
@@ -289,10 +289,15 @@ class Writer {
 				if( infos.catchLength != null ) {
 					flags |= 1;
 					o.writeUInt16( infos.catchLength );
+				} else {
+					o.writeUInt16( 0 );
 				}
+
 				if( infos.finallyLength != null ) {
 					flags |= 2;
 					o.writeUInt16( infos.finallyLength );
+				} else {
+					o.writeUInt16( 0 );
 				}
 				
 				switch( infos.style ) {


### PR DESCRIPTION
Writing out length is always required. `null` indicates lack of catch/finally block, `0` indicates an empty block, e.g. `catch(e) { }`.