### PR TITLE
Amf3 class handling

### DIFF
--- a/format/amf3/Reader.hx
+++ b/format/amf3/Reader.hx
@@ -75,7 +75,7 @@ class Reader {
 			var refTraits = objectTraitsTable[n];
 			dyn = refTraits.isDynamic;
 			isExternalizable = refTraits.isExternalizable;
-			//className = refTraits.className;
+			className = refTraits.className;
 			//trace(Tools.decode(className));  // TODO make registered class feature or use Type.resolveClass?
 			sealedMemberNames = refTraits.sealedMemberNames;
 		}
@@ -114,7 +114,7 @@ class Reader {
 
 		var h = new Map();
 
-		var ret = AObject( h );
+		var ret = AObject( h, className != null ? Tools.decode(className) : null );
 
 		// save new object in reference table
 		complexObjectsTable.push( ret );
@@ -210,7 +210,7 @@ class Reader {
 			a[r] = AInt( i.readInt32() );
 		}
 
-		var ret = fixed? AVector( a ) : AArray( a );
+		var ret = fixed? AVector( a, "Int" ) : AArray( a );
 
 		complexObjectsTable.push(ret);
 
@@ -238,7 +238,7 @@ class Reader {
 			a[r] = ANumber( i.readDouble() );
 		}
 
-		var ret = fixed? AVector( a ) : AArray( a );
+		var ret = fixed? AVector( a, "Number" ) : AArray( a );
 
 		complexObjectsTable.push(ret);
 
@@ -264,7 +264,7 @@ class Reader {
 		if( fixed )
 		{
 			a = new Vector(len);
-			ret = AVector( a );
+			ret = AVector( a, objectTypeName );
 		}
 		else
 		{

--- a/format/amf3/Reader.hx
+++ b/format/amf3/Reader.hx
@@ -71,7 +71,7 @@ class Reader {
 		else if( n & 3 == 1 )
 		{
 			// object traits reference
-			n >>= 3;
+			n >>= 2;
 			var refTraits = objectTraitsTable[n];
 			dyn = refTraits.isDynamic;
 			isExternalizable = refTraits.isExternalizable;

--- a/format/amf3/Tools.hx
+++ b/format/amf3/Tools.hx
@@ -42,7 +42,7 @@ class Tools {
 			for ( f in Reflect.fields(o) ) {
 				h.set(f, encode(Reflect.field(o, f)));
 			}
-			AObject(h);
+			AObject(h, null);
 		case TClass(c):
 			switch( c ) {
 			case cast String:
@@ -77,7 +77,7 @@ class Tools {
 				var a = new Vector<Value>(o.length);
 				for(i in 0...o.length)
 					a[i] = encode(o[i]);
-				AVector(a);
+				AVector(a, null);
 			#end
 			case cast haxe.io.Bytes:
 				ABytes(o);
@@ -86,11 +86,12 @@ class Tools {
 			case _:
 				var h = new Map();
 				var i = 0;
-				for ( f in Type.getInstanceFields(Type.getClass(o)) ) {
+				var _class = Type.getClass(o);
+				for ( f in Type.getInstanceFields(_class) ) {
 					h.set(f, encode(Reflect.getProperty(o, f)));
 					i++;
 				}
-				AObject(h, i);
+				AObject(h, Type.getClassName(_class), i);
 			}
 		default:
 			throw "Can't encode "+Std.string(o);
@@ -181,7 +182,7 @@ class Tools {
 	public static function vector( a : Value ) {
 		if( a == null ) return null;
 		return switch( a ) {
-			case AVector(a):
+			case AVector(a,_):
 				var v = new Vector<Dynamic>(a.length);
 				for (i in 0...a.length)
 					v[i] = decode(a[i]);

--- a/format/amf3/Value.hx
+++ b/format/amf3/Value.hx
@@ -36,9 +36,9 @@ enum Value {
 	ANumber( f : Float );
 	AString( s : String );
 	ADate( d : Date );
-	AObject( fields : Map<String,Value>, ?size : Int );
+	AObject( fields : Map<String,Value>, classname: String, ?size : Int );
 	AArray( values : Array<Value>, ?extra : Map<String,Value> );
-	AVector( values : Vector<Value> );
+	AVector( values : Vector<Value>, classname: String );
 	AXml( x : Xml );
 	ABytes( b : haxe.io.Bytes );
 	AMap( m : Map<Value, Value> );


### PR DESCRIPTION
Fix a small bug in readObject(), allowing file with traits reference.

Extend the AObject enum to have the class name in it. This allows external method to deserialise the objects with proper classes.

I have a code that convert from Value to object using a registrer (like using registerClassAlias).

I can submit it if anyone is interested 