### PR TITLE
Amf3 test and regression bugfix

### DIFF
--- a/format/amf3/Reader.hx
+++ b/format/amf3/Reader.hx
@@ -114,7 +114,7 @@ class Reader {
 
 		var h = new Map();
 
-		var ret = AObject( h, className != null ? Tools.decode(className) : null );
+		var ret = AObject( h, null, className != null ? Tools.decode(className) : null );
 
 		// save new object in reference table
 		complexObjectsTable.push( ret );

--- a/format/amf3/Tools.hx
+++ b/format/amf3/Tools.hx
@@ -42,7 +42,7 @@ class Tools {
 			for ( f in Reflect.fields(o) ) {
 				h.set(f, encode(Reflect.field(o, f)));
 			}
-			AObject(h, null);
+			AObject(h, null, null);
 		case TClass(c):
 			switch( c ) {
 			case cast String:
@@ -91,7 +91,7 @@ class Tools {
 					h.set(f, encode(Reflect.getProperty(o, f)));
 					i++;
 				}
-				AObject(h, Type.getClassName(_class), i);
+				AObject(h, i, Type.getClassName(_class));
 			}
 		default:
 			throw "Can't encode "+Std.string(o);
@@ -109,7 +109,7 @@ class Tools {
 			case ADate(_): date(a);
 			case AArray(_,_): array(a);
 			case AVector(_): vector(a);
-			case AObject(_,_): object(a);
+			case AObject(_,_,_): object(a);
 			case AXml(_): xml(a);
 			case ABytes(_): bytes(a);
 			case AMap(_): map(a);
@@ -194,7 +194,7 @@ class Tools {
 	public static function object( a : Value ) {
 		if( a == null ) return null;
 		return switch( a ) {
-		case AObject(o, _):
+		case AObject(o, _, _):
 			var m = new Map();
 			for (f in o.keys())
 				m.set(f, decode(o.get(f)));

--- a/format/amf3/Value.hx
+++ b/format/amf3/Value.hx
@@ -36,9 +36,9 @@ enum Value {
 	ANumber( f : Float );
 	AString( s : String );
 	ADate( d : Date );
-	AObject( fields : Map<String,Value>, classname: String, ?size : Int );
+	AObject( fields : Map<String,Value>, ?size : Int, ?classname: String );
 	AArray( values : Array<Value>, ?extra : Map<String,Value> );
-	AVector( values : Vector<Value>, classname: String );
+	AVector( values : Vector<Value>, ?classname: String );
 	AXml( x : Xml );
 	ABytes( b : haxe.io.Bytes );
 	AMap( m : Map<Value, Value> );

--- a/tests/amf3/TestAmf3.hx
+++ b/tests/amf3/TestAmf3.hx
@@ -1,0 +1,57 @@
+import utest.Assert;
+
+import format.amf3.Reader;
+import format.amf3.Writer;
+import format.amf3.Tools;
+import format.amf3.Value;
+
+
+class TestAmf3 {
+	public static function main() {
+		utest.UTest.run([new TestObject()]);
+	}
+}
+
+class TestObject extends utest.Test {
+	private var obj = { a: [1, 2, 3], b: 1, c: 1.1, d: "string", e: true, f: null };
+
+	function testWriteRead() {
+		// write
+		var output = new haxe.io.BytesOutput();
+		var writer = new Writer(output);
+		writer.write(Tools.encode(obj));
+		var bytes = output.getBytes();
+
+		// read
+		var input = new haxe.io.BytesInput(bytes, 0);
+		var reader = new Reader(input);
+		var decodedObj = Aux.unwrap(reader.read());
+
+		Assert.same(obj, decodedObj);
+	}
+}
+
+class Aux {
+	public static function unwrap(val:Value):Dynamic
+	{
+		return switch (val)
+		{
+			case ANumber(f): return f;
+			case AInt(n): return n;
+			case ABool(b): return b;
+			case AString(s): return s;
+			case AUndefined: return null;
+			case ANull: return null;
+			case AArray(vals): return vals.map(unwrap);
+			case AVector(vals): return vals.map(unwrap);
+			case AObject(vmap):
+				var obj = {};
+				for (name in vmap.keys())
+				{
+					Reflect.setField(obj, name, unwrap(vmap[name]));
+				}
+				return obj;
+			default: throw "not implemented";
+		}
+	}
+}

--- a/tests/amf3/build.hxml
+++ b/tests/amf3/build.hxml
@@ -1,0 +1,10 @@
+-neko bin/test_amf.n
+-main TestAmf3	
+-lib utest
+-cp ../..
+
+--next
+-js bin/test_amf.js
+-main TestAmf3	
+-lib utest
+-cp ../..


### PR DESCRIPTION
The changes in `Value.AObject` from the recent ac10f3f caused `amf3.Writer` to fail. This PR:

- Adds an amf3 test that reproduces the issue
- Makes `classname` in `amf3.Value` optional (and last in order), to maintain compatibility with `Writer` and any external code using `amf3.Value` (eg. https://github.com/openfl/openfl/blob/1628cf58c1a0b2d556b31215d152641bb85fa379/packages/utils/src/openfl/utils/ByteArray.hx#L1388)