### PR TITLE
Amf3 utf8 fixes

### DIFF
--- a/format/amf3/Reader.hx
+++ b/format/amf3/Reader.hx
@@ -344,10 +344,9 @@ class Reader {
 			return AString( "" );  // 0x01 is empty string and is never sent by reference
 		// get the string characters
 		#if haxe4
-		var u:UnicodeString = "";
+		var ret = AString( i.readString(len, UTF8) );
 		#else
 		var u = new haxe.Utf8(len);
-		#end
 		var c = 0, d = 0, j:Int = 0, it = 0;
 		while (j < len) {
 			c = i.readByte();
@@ -374,14 +373,12 @@ class Reader {
 			}
 			j += it + 1;
 			if (d != 0x01) {
-				#if haxe4
-				u += String.fromCharCode(d);
-				#else
 				u.addChar(d);
-				#end
 			}
 		}
 		var ret = AString( u.toString() );
+		#end
+
 		// store the string off for if it gets referenced later
 		stringTable.push(ret);
 		return ret;

--- a/format/amf3/Writer.hx
+++ b/format/amf3/Writer.hx
@@ -77,6 +77,12 @@ class Writer {
 	}
 	
 	function writeString( s : String ) {
+		#if haxe4
+		var bytes = haxe.io.Bytes.ofString(s, UTF8);
+		writeUInt(bytes.length, true);
+		o.writeBytes(bytes, 0, bytes.length);
+		#else
+		// TODO: multibyte chars are broken in haxe3, we need to write the length in bytes!
 		writeUInt(s.length, true);
 		var j = 0, it = 0;
 		for (i in 0...s.length) {
@@ -103,6 +109,7 @@ class Writer {
 			while (it-- > 0)
 				o.writeByte(j >> (6 * it));
 		}
+		#end
 	}
 	
 	function writeObject( h : Map<String, Value>, ?size : Int ) {

--- a/tests/amf3/TestAmf3.hx
+++ b/tests/amf3/TestAmf3.hx
@@ -8,12 +8,12 @@ import format.amf3.Value;
 
 class TestAmf3 {
 	public static function main() {
-		utest.UTest.run([new TestObject()]);
+		utest.UTest.run([new TestObject(), new TestUtf8()]);
 	}
 }
 
 class TestObject extends utest.Test {
-	private var obj = { a: [1, 2, 3], b: 1, c: 1.1, d: "string", e: true, f: null };
+	private var obj = { a: [1, 2, 3], b: 1, c: 1.1, d: Aux.str, e: true, f: null };
 
 	function testWriteRead() {
 		// write
@@ -31,7 +31,36 @@ class TestObject extends utest.Test {
 	}
 }
 
+class TestUtf8 extends utest.Test {
+
+	function testWriteRead() {
+		// write
+		var output = new haxe.io.BytesOutput();
+		var writer = new Writer(output);
+		writer.write(Tools.encode(Aux.str));
+		var bytes = output.getBytes();
+
+		Assert.equals(Aux.str_expected_amf, bytes.toHex());
+
+		// read
+		var input = new haxe.io.BytesInput(bytes, 0);
+		var reader = new Reader(input);
+		var decodedStr = Aux.unwrap(reader.read());
+
+		Assert.equals(Aux.str, decodedStr);
+	}
+}
+
 class Aux {
+	// Test multi-byte chars only in haxe4 (the amf3 Writer is broken for multi-byte chars in haxe3)
+	#if haxe4
+	public static var str = "Οὐχὶ ταὐτὰ παρίσταταί μοι γιγνώσκειν, ὦ ἄνδρες ᾿Αθηναῖοι";
+	public static var str_expected_amf = "068167ce9fe1bd90cf87e1bdb620cf84ceb1e1bd90cf84e1bdb020cf80ceb1cf81e1bdb7cf83cf84ceb1cf84ceb1e1bdb720cebccebfceb920ceb3ceb9ceb3cebde1bdbdcf83cebaceb5ceb9cebd2c20e1bda620e1bc84cebdceb4cf81ceb5cf8220e1bebfce91ceb8ceb7cebdceb1e1bf96cebfceb9";
+	#else
+	public static var str = "single byte string";
+	public static var str_expected_amf = "062573696e676c65206279746520737472696e67";
+	#end
+
 	public static function unwrap(val:Value):Dynamic
 	{
 		return switch (val)


### PR DESCRIPTION
The current amf3 `Writer` is broken for multibyte chars (it needs to write the length in bytes, not chars). This PR:
- adds a utf8 test for amf3
- Changes the `Writer` to use haxe4's native utf8 (simpler, faster and correct)

  I didn't touch the haxe3 implementation cause I'm not sure what is the best way to fix it, and anyone who seriously needs multibyte support should move to haxe4 anyway. The test passes for both haxe3 & haxe4, because it tests multibyte chars only under haxe4.

