### PR TITLE
[swf] PlaceObject3 reader bug fix

### DIFF
--- a/format/swf/Reader.hx
+++ b/format/swf/Reader.hx
@@ -958,7 +958,7 @@ class Reader {
 		if( f2 >> 5 != 0 ) throw error(); // unsupported bit flags
 		var po = new PlaceObject();
 		po.depth = i.readUInt16();
-		if( f2 & 8 != 0 || (f2 & 16 != 0 && f & 2 != 0) ) po.className = readUTF8Bytes().toString();
+		if( f2 & 8 != 0 ) po.className = readUTF8Bytes().toString();
 		if( f & 1 != 0 ) po.move = true;
 		if( f & 2 != 0 ) po.cid = i.readUInt16();
 		if( f & 4 != 0 ) po.matrix = readMatrix();


### PR DESCRIPTION
ClassName type for PlaceObject3 `("PlaceFlagHasClassName or (PlaceFlagHasImage and PlaceFlagHasCharacter), String")` contradicts the description for PlaceFlagHasImage `("Has class name or character ID of bitmap to place. If PlaceFlagHasClassName, use ClassName. If PlaceFlagHasCharacter, use CharacterId")`, but the latter is correct. This fixed the errors in my output SWF. I also checked FFDec does it this way as well.