### PR TITLE
Fix extract32 for indexed pngs that have a bit depth less than 4 bits.

### DIFF
--- a/format/png/Tools.hx
+++ b/format/png/Tools.hx
@@ -271,8 +271,7 @@ class Tools {
 			var bgra = format.tools.MemoryBytes.make(start);
 			#end
 
-			var tmp = (h.width * h.colbits);
-			var rline = tmp >> 3;
+			var rline = stride - 1;
 			for( y in 0...h.height ) {
 				var f = data.get(r++);
 				if( f == 0 ) {


### PR DESCRIPTION
When running extract32 on indexed pngs that have less than 4 bits depth the rline number is off, resulting in an "invalid filter" error.
This is because the bit shifting takes too many numbers off. The rline is the same as the `stride - 1` so I used that instead.