### PR TITLE
Fix ColGrey(true) filter method 2

### DIFF
--- a/format/png/Tools.hx
+++ b/format/png/Tools.hx
@@ -433,7 +433,8 @@ class Tools {
 							bgra.set(w++, v);
 							bgra.set(w++, v);
 							bgra.set(w++, v);
-							bgra.set(w++, data.get(r++) + bgra.get(w - stride));
+							var va = data.get(r++) + bgra.get(w - stride);
+							bgra.set(w++, va);
 						}
 					else
 						for( x in 0...width ) {


### PR DESCRIPTION
Fixes the greyscale-with-alpha image format decoding when filter method 2 is used.
Instead of using the alpha value of the previous scanline it used the blue value of the next pixel on a previous scanline due to `w` being incremented
Sample image/expected result:
![icon_grayscale](https://user-images.githubusercontent.com/1061373/181531937-d0aa9696-646a-4b96-950b-dda7d108aa8b.png)
Current behavior of the `extract32` due to the aforementioned issue:
![eval 32bgra](https://user-images.githubusercontent.com/1061373/181537675-36f2f8fd-1878-4226-b90b-02ae701d9052.png)

