### PR TITLE
Added .ico file format reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Currently supported formats are :
 | GIF | Image file format | ☑ | ☑ |
 | GZ | Compressed file | ☑ | ❌ |
 | HL | HashLink | ☑ | ❌ |
+| ICO | Windows ICO/CUR File format | ☑ | ❌ |
 | JPG | Image file format | ❌ | ☑ |
 | LZ4 | Compressed file | ☑ | ❌ |
 | MP3 | Compressed audio | ☑ | ☑ |

--- a/format/ico/DIB.hx
+++ b/format/ico/DIB.hx
@@ -1,0 +1,77 @@
+package format.ico;
+
+import format.ico.Data;
+
+/**
+* Device-Independent Bitmap
+*/
+class DIB {
+	public var data(default, null) : haxe.io.Bytes;
+	public var info(default, null) : BMPInfo;
+	public var ixor(default, null) : Int;
+	public var iand(default, null) : Int;
+	public var width(default, null) : Int;
+	public var height(default, null) : Int;
+	public var colors(default, null) : Array<Int>;
+	public function new( data, info ) {
+		this.data = data;
+		this.info = info;
+		this.width = info.width;
+		this.height = info.height >> 1;
+		this.ixor = info.findDIBBits();
+		this.iand = this.ixor + this.height * info.bytesPerline();
+		this.colors = [];
+		var ptr = info.sizeof;
+		var max = ptr + info.numberColors() * 4;
+		while(ptr < max) {
+			this.colors.push(data.getInt32(ptr));
+			ptr += 4;
+		}
+	}
+}
+
+/**
+* For .ico file format, Only the following members are used:
+*
+* sizeof, width, height, planes, bitCount, sizeImage. All other members must be 0.
+*/
+class BMPInfo {
+	public var sizeof : Int;        // DWORD, size of the structure = 40
+	public var width : Int;         // DWORD, width of the image in pixels
+	public var height : Int;        // DWORD, height of the image in pixels, (negative: top-down, positive: bottom-up)
+	public var planes : Int;        //  WORD, = 1
+	public var bitCount : Int;      //  WORD, bits per pixel (1, 4, 8, 16, 24, or 32)
+	public var compression : Int;   // DWORD, compression code
+	public var sizeImage : Int;     // DWORD, number of bytes in image
+	public var xPelsPerMeter : Int; // DWORD, horizontal resolution
+	public var yPelsPermeter : Int; // DWORD, vertical resolution
+	public var clrUsed : Int;       // DWORD, number of colors used
+	public var clrImportant : Int;  // DWORD, number of important colors
+
+	public function new() {
+	}
+
+	// Calculates the number of entries in the color table.
+	public function numberColors() : Int {
+		if (clrUsed > 0)
+			return clrUsed;
+		return switch(bitCount) {   // 1 << bitCount
+		case 1:    2;
+		case 4:   16;
+		case 8:  256;
+		default:   0;
+		}
+	}
+
+	// Calculates the number of bytes in the color table.
+	public inline function paletteSize() return numberColors() * 4;
+
+	// Locate the image bits in a CF_DIB format DIB.
+	public inline function findDIBBits() return sizeof + paletteSize();
+
+	// Calculates the number of bytes in one scan line from Indexes
+	public inline function bytesPerline() return WIDTHBYTES(width * bitCount);
+
+	// Multiple of 4
+	static public inline function WIDTHBYTES( bits ) return bits + 31 >> 5 << 2;
+}

--- a/format/ico/Data.hx
+++ b/format/ico/Data.hx
@@ -29,8 +29,8 @@ class ICOEntry {
 	public var height : Int;        // BYTE
 	public var colorCount : Int;    // BYTE
 	public var reserved : Int;      // BYTE
-	public var planes : Int;        // WORD
-	public var bitCount : Int;      // WORD
+	public var planes : Int;        // WORD, (x hotspot if CURSOR)
+	public var bitCount : Int;      // WORD, (y hotspot if CURSOR)
 	public var size : Int;          // DWORD
 	public var offset : Int;        // DWORD
 	public function new() {

--- a/format/ico/Data.hx
+++ b/format/ico/Data.hx
@@ -44,7 +44,7 @@ class DIB {
 	public var iand(default, null) : Int;
 	public var width(default, null) : Int;
 	public var height(default, null) : Int;
-	public var colors(default, null) : Array<Int>; // RGB
+	public var colors(default, null) : Array<Int>; // 0RGB
 	public function new( data, info ) {
 		this.data = data;
 		this.info = info;
@@ -87,7 +87,7 @@ class BMPInfo {
 	public function numberColors() : Int {
 		if (clrUsed > 0)
 			return clrUsed;
-		return switch(bitCount) {   // Math.pow(2, bitCount)
+		return switch(bitCount) {   // 1 << bitCount
 		case 1:    2;
 		case 4:   16;
 		case 8:  256;
@@ -101,6 +101,8 @@ class BMPInfo {
 	// Locate the image bits in a CF_DIB format DIB.
 	public inline function findDIBBits() return sizeof + paletteSize();
 
-	// Calculates the number of bytes in one scan line.
-	public inline function bytesPerline() return ((width * planes * bitCount + 31) >> 5) << 2;
+	// Calculates the number of bytes in one scan line from Indexes
+	public inline function bytesPerline() return WIDTHBYTES(width * bitCount);
+
+	static public inline function WIDTHBYTES( bits ) return bits + 31 >> 5 << 2;
 }

--- a/format/ico/Data.hx
+++ b/format/ico/Data.hx
@@ -1,15 +1,10 @@
 package format.ico;
 
-// https://docs.fileformat.com/image/ico/
+import format.ico.DIB;
 
 enum Data {
 	DIB( d : DIB );
 	PNG( b : haxe.io.Bytes );
-}
-
-private extern enum abstract ICOType(Int) to Int {
-	var ICON = 1;
-	var CURSOR = 2;
 }
 
 class ICORoot {
@@ -37,73 +32,7 @@ class ICOEntry {
 	}
 }
 
-class DIB {
-	public var data(default, null) : haxe.io.Bytes;
-	public var info(default, null) : BMPInfo;
-	public var ixor(default, null) : Int;
-	public var iand(default, null) : Int;
-	public var width(default, null) : Int;
-	public var height(default, null) : Int;
-	public var colors(default, null) : Array<Int>; // 0RGB
-	public function new( data, info ) {
-		this.data = data;
-		this.info = info;
-		this.width = info.width;
-		this.height = info.height >> 1;
-		this.ixor = info.findDIBBits();
-		this.iand = this.ixor + this.height * info.bytesPerline();
-		this.colors = [];
-		var ptr = info.sizeof;
-		var max = ptr + info.numberColors() * 4;
-		while(ptr < max) {
-			this.colors.push(data.getInt32(ptr));
-			ptr += 4;
-		}
-	}
-}
-
-/**
- For .ico file format, Only the following members are used:
-
- sizeof, width, height, planes, bitCount, sizeImage. All other members must be 0.
-*/
-class BMPInfo {
-	public var sizeof : Int;        // DWORD, size of the structure = 40
-	public var width : Int;         // DWORD, width of the image in pixels
-	public var height : Int;        // DWORD, height of the image in pixels, (negative: top-down, positive: bottom-up)
-	public var planes : Int;        //  WORD, = 1
-	public var bitCount : Int;      //  WORD, bits per pixel (1, 4, 8, 16, 24, or 32)
-	public var compression : Int;   // DWORD, compression code
-	public var sizeImage : Int;     // DWORD, number of bytes in image
-	public var xPelsPerMeter : Int; // DWORD, horizontal resolution
-	public var yPelsPermeter : Int; // DWORD, vertical resolution
-	public var clrUsed : Int;       // DWORD, number of colors used
-	public var clrImportant : Int;  // DWORD, number of important colors
-
-	public function new() {
-	}
-
-	// Calculates the number of entries in the color table.
-	public function numberColors() : Int {
-		if (clrUsed > 0)
-			return clrUsed;
-		return switch(bitCount) {   // 1 << bitCount
-		case 1:    2;
-		case 4:   16;
-		case 8:  256;
-		default:   0;
-		}
-	}
-
-	// Calculates the number of bytes in the color table.
-	public inline function paletteSize() return numberColors() * 4;
-
-	// Locate the image bits in a CF_DIB format DIB.
-	public inline function findDIBBits() return sizeof + paletteSize();
-
-	// Calculates the number of bytes in one scan line from Indexes
-	public inline function bytesPerline() return WIDTHBYTES(width * bitCount);
-
-	// Multiple of 4
-	static public inline function WIDTHBYTES( bits ) return bits + 31 >> 5 << 2;
+extern enum abstract ICOType(Int) to Int {
+	var ICON = 1;
+	var CURSOR = 2;
 }

--- a/format/ico/Data.hx
+++ b/format/ico/Data.hx
@@ -1,0 +1,106 @@
+package format.ico;
+
+// https://docs.fileformat.com/image/ico/
+
+enum Data {
+	DIB( d : DIB );
+	PNG( b : haxe.io.Bytes );
+}
+
+private extern enum abstract ICOType(Int) to Int {
+	var ICON = 1;
+	var CURSOR = 2;
+}
+
+class ICORoot {
+	public var reserved : Int;      // WORD, Reserved (must be 0)
+	public var type  : ICOType;     // WORD
+	public var count : Int;         // WORD, length of entries
+	public var entries : Array<ICOEntry>;
+	public var datas : Array<Data>;
+	public function new() {
+		entries = [];
+		datas = [];
+	}
+}
+
+class ICOEntry {
+	public var width : Int;         // BYTE
+	public var height : Int;        // BYTE
+	public var colorCount : Int;    // BYTE
+	public var reserved : Int;      // BYTE
+	public var planes : Int;        // WORD
+	public var bitCount : Int;      // WORD
+	public var size : Int;          // DWORD
+	public var offset : Int;        // DWORD
+	public function new() {
+	}
+}
+
+class DIB {
+	public var data(default, null) : haxe.io.Bytes;
+	public var info(default, null) : BMPInfo;
+	public var ixor(default, null) : Int;
+	public var iand(default, null) : Int;
+	public var width(default, null) : Int;
+	public var height(default, null) : Int;
+	public var colors(default, null) : Array<Int>; // RGB
+	public function new( data, info ) {
+		this.data = data;
+		this.info = info;
+		this.width = info.width;
+		this.height = info.height >> 1;
+		this.ixor = info.findDIBBits();
+		this.iand = this.ixor + this.height * info.bytesPerline();
+		this.colors = [];
+		var ptr = info.sizeof;
+		var max = ptr + info.numberColors() * 4;
+		while(ptr < max) {
+			this.colors.push(data.getInt32(ptr));
+			ptr += 4;
+		}
+	}
+}
+
+/**
+ For .ico file format, Only the following members are used:
+
+ sizeof, width, height, planes, bitCount, sizeImage. All other members must be 0.
+*/
+class BMPInfo {
+	public var sizeof : Int;        // DWORD, size of the structure = 40
+	public var width : Int;         // DWORD, width of the image in pixels
+	public var height : Int;        // DWORD, height of the image in pixels, (negative: top-down, positive: bottom-up)
+	public var planes : Int;        //  WORD, = 1
+	public var bitCount : Int;      //  WORD, bits per pixel (1, 4, 8, 16, 24, or 32)
+	public var compression : Int;   // DWORD, compression code
+	public var sizeImage : Int;     // DWORD, number of bytes in image
+	public var xPelsPerMeter : Int; // DWORD, horizontal resolution
+	public var yPelsPermeter : Int; // DWORD, vertical resolution
+	public var clrUsed : Int;       // DWORD, number of colors used
+	public var clrImportant : Int;  // DWORD, number of important colors
+
+	public function new() {
+	}
+
+	// Calculates the number of entries in the color table.
+	public function numberColors() : Int {
+		if (clrUsed > 0)
+			return clrUsed;
+		return switch(bitCount) {   // Math.pow(2, bitCount)
+		case 1:    2;
+		case 4:   16;
+		case 8:  256;
+		default:   0;
+		}
+	}
+
+	// Calculates the number of bytes in the color table.
+	public inline function paletteSize() return numberColors() * 4;
+
+	// Locate the image bits in a CF_DIB format DIB.
+	public inline function findDIBBits() return sizeof + paletteSize();
+
+	// Calculates the number of bytes in one scan line.
+	public inline function bytesPerline() return ((width * planes * bitCount + 31) >> 5) << 2;
+}

--- a/format/ico/Data.hx
+++ b/format/ico/Data.hx
@@ -104,5 +104,6 @@ class BMPInfo {
 	// Calculates the number of bytes in one scan line from Indexes
 	public inline function bytesPerline() return WIDTHBYTES(width * bitCount);
 
+	// Multiple of 4
 	static public inline function WIDTHBYTES( bits ) return bits + 31 >> 5 << 2;
 }

--- a/format/ico/Reader.hx
+++ b/format/ico/Reader.hx
@@ -1,0 +1,70 @@
+package format.ico;
+
+import format.ico.Data;
+
+class Reader {
+
+	var input : haxe.io.Input;
+
+	inline function readUInt16() return input.readUInt16();
+	inline function readInt32() return input.readInt32();
+	inline function readByte() return input.readByte();
+
+	public function new(i) {
+		input = i;
+		input.bigEndian = false;
+	}
+
+	public function read() : ICORoot {
+		var root = new ICORoot();
+		root.reserved = input.readUInt16();
+		root.type = cast readUInt16();
+		root.count = readUInt16();
+
+		if (root.reserved != 0 || root.type != ICON)
+			throw "Invalid header";
+
+		for (i in 0...root.count) {
+			var entry = new ICOEntry();
+			entry.width = readByte();
+			entry.height = readByte();
+			entry.colorCount = readByte();
+			entry.reserved = readByte();
+			entry.planes = readUInt16();
+			entry.bitCount = readUInt16();
+			entry.size = readInt32();
+			entry.offset = readInt32();
+			root.entries.push(entry);
+		}
+
+		for (entry in root.entries) {
+			var bmp = haxe.io.Bytes.alloc(entry.size);
+			input.readBytes(bmp, 0, entry.size);
+
+			if (bmp.getInt32(0) == PNG_SIGN) {
+				root.datas.push( PNG(bmp) );
+				continue;
+			}
+
+			var info = new BMPInfo();
+			info.sizeof        = bmp.getInt32(0);
+			info.width         = bmp.getInt32(1 * 4);
+			info.height        = bmp.getInt32(2 * 4);
+			info.planes        = bmp.getUInt16(3 * 4);
+			info.bitCount      = bmp.getUInt16(3 * 4 + 2);
+			info.compression   = bmp.getInt32(4 * 4);
+			info.sizeImage     = bmp.getInt32(5 * 4);
+			info.xPelsPerMeter = bmp.getInt32(6 * 4);
+			info.yPelsPermeter = bmp.getInt32(7 * 4);
+			info.clrUsed       = bmp.getInt32(8 * 4);
+			info.clrImportant  = bmp.getInt32(9 * 4);
+
+			var image = new DIB(bmp, info);
+			root.datas.push(DIB(image));
+		}
+		input = null;
+		return root;
+	}
+
+	static inline var PNG_SIGN = 0x89 | ("P".code << 8) | ("N".code << 16) | ("G".code << 24);
+}

--- a/format/ico/Reader.hx
+++ b/format/ico/Reader.hx
@@ -17,23 +17,23 @@ class Reader {
 
 	public function read() : ICORoot {
 		var root = new ICORoot();
-		root.reserved = input.readUInt16();
+		root.reserved = readUInt16();
 		root.type = cast readUInt16();
 		root.count = readUInt16();
 
-		if (root.reserved != 0 || root.type != ICON)
-			throw "Invalid header";
+		if (root.reserved != 0)
+			return root; // empty
 
 		for (i in 0...root.count) {
 			var entry = new ICOEntry();
-			entry.width = readByte();
-			entry.height = readByte();
-			entry.colorCount = readByte();
-			entry.reserved = readByte();
-			entry.planes = readUInt16();
-			entry.bitCount = readUInt16();
-			entry.size = readInt32();
-			entry.offset = readInt32();
+			entry.width        = readByte();
+			entry.height       = readByte();
+			entry.colorCount   = readByte();
+			entry.reserved     = readByte();
+			entry.planes       = readUInt16();
+			entry.bitCount     = readUInt16();
+			entry.size         = readInt32();
+			entry.offset       = readInt32();
 			root.entries.push(entry);
 		}
 

--- a/format/ico/Reader.hx
+++ b/format/ico/Reader.hx
@@ -1,6 +1,7 @@
 package format.ico;
 
 import format.ico.Data;
+import format.ico.DIB;
 
 class Reader {
 

--- a/format/ico/Tools.hx
+++ b/format/ico/Tools.hx
@@ -1,11 +1,12 @@
 package format.ico;
 
 import format.ico.Data;
+import format.ico.DIB;
 
 class Tools {
 
 	/**
-	 extract DIB to [R, G, B, A, ...] format
+	* extract DIB to [R, G, B, A, ...] format
 	*/
 	static public function extract( bmp : DIB ) : Uint8Array {
 		// fast reference

--- a/format/ico/Tools.hx
+++ b/format/ico/Tools.hx
@@ -68,7 +68,7 @@ class Tools {
 					output[index++] = source.get(starts + column + 2);
 					output[index++] = source.get(starts + column + 1);
 					output[index++] = source.get(starts + column + 0);
-					output[index++] = masks[ptrmak] - 1; //  m == 1 ? 0 : -1;
+					output[index++] = masks[ptrmak] - 1; // m == 1 ? 0 : -1;
 					column += 3;
 					ptrmak ++;
 				}
@@ -103,7 +103,7 @@ class Tools {
 		return i;
 	}
 
-	static function buildMasks( bmp : DIB ) : Uint8Array { //
+	static function buildMasks( bmp : DIB ) : Uint8Array {
 		var data = bmp.data;
 		var base = bmp.iand;
 		var width = bmp.height;

--- a/format/ico/Tools.hx
+++ b/format/ico/Tools.hx
@@ -57,6 +57,22 @@ class Tools {
 					index = write(output, index, colors[icx], masks[pos]);
 				}
 			}
+		case 6: // 24bits with 1 alpha bit
+			var masks = buildMasks(bmp);
+			var ptrmak = 0;
+			while (--height >= 0) {
+				starts = height * stride + base;
+				ptrmak = height * bmp.width;
+				column = 0;
+				while (column < stride) {
+					output[index++] = source.get(starts + column + 2);
+					output[index++] = source.get(starts + column + 1);
+					output[index++] = source.get(starts + column + 0);
+					output[index++] = masks[ptrmak] - 1; //  m == 1 ? 0 : -1;
+					column += 3;
+					ptrmak ++;
+				}
+			}
 		case 8: // 32bits
 			while (--height >= 0) {
 				starts = base + height * stride;
@@ -71,7 +87,6 @@ class Tools {
 				}
 			}
 		default:
-			// TODO: There is no documentation for 16, 24bits
 		}
 		return output;
 	}

--- a/format/ico/Tools.hx
+++ b/format/ico/Tools.hx
@@ -1,0 +1,147 @@
+package format.ico;
+
+import format.ico.Data;
+
+class Tools {
+
+	/**
+	 extract DIB to [R, G, B, A, ...] format
+	*/
+	static public function extract( bmp : DIB ) : Uint8Array {
+		var source = bmp.data;
+		var height = bmp.height;
+		var colors = bmp.colors;
+		var stride = bmp.info.bytesPerline();
+		var output = new Uint8Array(bmp.width * height * 4);
+		var base = bmp.ixor;
+		var index = 0;
+		var column : Int;
+		var starts : Int;
+		switch (bmp.info.bitCount >> 2) { // shrink switch table
+		case 0: // 1bits
+			var mask = bmp.iand;
+			var realWidth = bmp.width >> 3;
+			while (--height >= 0) {
+				starts = height * stride;
+				column = 0;
+				while (column < realWidth) {
+					var pos = starts + column++;
+					var icx = source.get(base + pos);
+					var mak = source.get(mask + pos);
+					var bits = 8;
+					while(--bits >= 0) {
+						index = write(output, index, colors[(icx >> bits) & 1], (mak >> bits) & 1);
+					}
+				}
+			}
+		case 1: // 4bits
+			var masks = buildMasks(bmp);
+			while (--height >= 0) {
+				starts = height * stride;
+				column = 0;
+				while (column < stride) {
+					var pos = starts + column++;
+					var icx = source.get(base + pos);
+					index = write(output, index, colors[(icx >> 4) & 15], masks[(pos << 1) + 0]);
+					index = write(output, index, colors[(icx >> 0) & 15], masks[(pos << 1) + 1]);
+				}
+			}
+		case 2: // 8bits
+			var masks = buildMasks(bmp);
+			while (--height >= 0) {
+				starts = height * stride;
+				column = 0;
+				while (column < stride) {
+					var pos = starts + column++;
+					var icx = source.get(base + pos);
+					index = write(output, index, colors[icx], masks[pos]);
+				}
+			}
+		case 8: // 32bits
+			while (--height >= 0) {
+				starts = base + height * stride;
+				column = 0;
+				while (column < stride) {
+					var argb = source.getInt32(starts + column);
+					output[index++] = (argb >> 16) & 0xFF;
+					output[index++] = (argb >>  8) & 0xFF;
+					output[index++] = (argb >>  0) & 0xFF;
+					output[index++] = (argb >> 24) & 0xFF;
+					column += 4;
+				}
+			}
+		default:
+			// TODO: There is no documentation for 16, 24bits
+		}
+		return output;
+	}
+
+	static function write( output : Uint8Array, i : Int, rgb : Int, ts : Int ) : Int {
+		if (ts == 1) {
+			output[i + 3] = 0;
+			return i + 4;
+		}
+		output[i++] = (rgb >> 16) & 0xFF;
+		output[i++] = (rgb >>  8) & 0xFF;
+		output[i++] = rgb & 0xFF;
+		output[i++] = 0xFF;
+		return i;
+	}
+
+	static function buildMasks( bmp : DIB ) : Uint8Array { //
+		var data = bmp.data;
+		var base = bmp.iand;
+		var width = bmp.height;
+		var height = bmp.height;
+		var realWidth = width >> 3;
+		var stride = BMPInfo.WIDTHBYTES(width);
+		var output = new Uint8Array(height * width);
+		var i = 0;
+		var h = 0;
+		while(h < height) {
+			var column = 0;
+			var starts = base + h * stride;
+			while(column < realWidth) {
+				var mark = data.get(starts + column++);
+				var bits = 8;
+				while (--bits >= 0) {
+					output[i++] = (mark >> bits) & 1;
+				}
+			}
+			h++;
+		}
+		return output;
+	}
+}
+
+#if js
+typedef Uint8ArrayInner = js.lib.Uint8Array;
+#elseif hl
+typedef Uint8ArrayInner = hl.Bytes;
+#else
+typedef Uint8ArrayInner = haxe.io.Bytes;
+#end
+
+@:pure
+@:forward(length)
+extern abstract Uint8Array(Uint8ArrayInner) to Uint8ArrayInner {
+#if (js || hl)
+	inline function new( size : Int ) this = new Uint8ArrayInner(size);
+
+	@:arrayAccess inline private function get( pos : Int ) : Int return this[pos];
+
+	@:arrayAccess inline private function set( pos : Int, value : Int ) : Int return this[pos] = value;
+
+#else
+	inline function new( size : Int ) this = haxe.io.Bytes.alloc(size);
+
+	@:arrayAccess inline private function get( pos : Int ) : Int {
+		return this.get(pos);
+	}
+
+	@:arrayAccess inline private function set( pos : Int, value : Int ) : Int {
+		this.set(pos, value);
+		return value;
+	}
+#end
+}

--- a/format/ico/Tools.hx
+++ b/format/ico/Tools.hx
@@ -37,15 +37,10 @@ class Tools {
 					var bits = 8;
 					while (--bits >= 0 && index < limits) {
 						var rgb = colors[icx >> bits & 1];
-						if ((mak >> bits & 1) == 1) {
-							output[index + 3] = 0;
-							index += 4;
-							continue;
-						}
 						output[index++] = rgb >> 16 & 0xFF;
 						output[index++] = rgb >>  8 & 0xFF;
 						output[index++] = rgb & 0xFF;
-						output[index++] = 0xFF;
+						output[index++] = (mak >> bits & 1) - 1;
 					}
 				}
 				limits += rowlen;
@@ -62,7 +57,7 @@ class Tools {
 
 					// if the iamge width is not multiple of 2
 					if (column == byteWidth && (byteWidth & 1) == 1)
-						continue;
+						break;
 
 					writeRGB(output, index, colors[(icx     ) & 15]);
 					index += 4;


### PR DESCRIPTION
It read each DIB(currently only bottom-up format) pixels in .ico file to [R,G,B,A...] byte sequence.

demo: load ico to canvas
![ico-format](https://user-images.githubusercontent.com/6825113/188261601-ea0cec10-b90e-4dff-8006-e7ff2cc91a39.jpg)

For .ico creation, either `GIMP` or `Visual Studio` can be used
